### PR TITLE
Fix position of arrow in example

### DIFF
--- a/src/rules/dollar-variable-pattern/README.md
+++ b/src/rules/dollar-variable-pattern/README.md
@@ -4,7 +4,7 @@ Specify a pattern for Sass-like variables.
 
 ```css
 a { $foo: 1px; }
-/**   ↑
+/** ↑
  * The pattern of this */
 ```
 


### PR DESCRIPTION
I’m not sure how stringently you wish to adhere to the stylelint conventions in this repo, but we align the arrows in examples to *the beginning* of the things being highlighted because the ambiguity of not doing so got confusing on some rules.

The `dollar-variable-pattern` rule looks awesome btw. Everything else looks perfect! (except the deprecation of `stylelint-rule-tester`, but there’s another issue for that)

As this is a fledgling repo, I’ll try to pop in when I can if I spot something where I can pass on a lesson we learnt in building the rules for core. To save you guys making the same mistakes we did :)