### PR TITLE
Add `stylelint-plugin` keyword to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "csslint",
     "lint",
     "linter",
-    "stylelint"
+    "stylelint",
+    "stylelint-plugin"
   ],
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
Now that stylelint recommends adding `stylelint-keyword` to NPM packages to aid in discoverability of stylelint plugins: http://stylelint.io/developer-guide/plugins/#sharing-plugins