### PR TITLE
selector-no-redundant-nesting-selector: fix false positives, fixes #32

### DIFF
--- a/src/rules/selector-no-redundant-nesting-selector/__tests__/index.js
+++ b/src/rules/selector-no-redundant-nesting-selector/__tests__/index.js
@@ -45,13 +45,6 @@ testRule(rule, {
   }, {
     code: `
       p {
-        & + .foo {}
-      }
-    `,
-    description: "when an ampersand precedes a sibling operator",
-  }, {
-    code: `
-      p {
         & + &:hover {}
       }
     `,
@@ -88,6 +81,36 @@ testRule(rule, {
       }
     `,
     description: "when an ampersand is used in an attribute selector",
+  }, {
+    code: `
+      .foo {
+        &bar {
+          &baz {}
+        }
+      }
+    `,
+    description: "when an ampersand is used to combine three parts of a classname",
+  }, {
+    code: `
+      .foo {
+        &bar {}
+      }
+    `,
+    description: "when an ampersand is used to combine two parts of a classname",
+  }, {
+    code: `
+      .block {
+        &__element {}
+      }
+    `,
+    description: "when BEM syntax element is used",
+  }, {
+    code: `
+      .block {
+        &--modifier {}
+      }
+    `,
+    description: "when BEM syntax modifier is used",
   } ],
 
   reject: [ {
@@ -125,7 +148,7 @@ testRule(rule, {
     `,
     line: 3,
     message: messages.rejected,
-    description: "when an amperand precedes a general child",
+    description: "when an amperand precedes an element",
   }, {
     code: `
       p {
@@ -135,6 +158,53 @@ testRule(rule, {
     line: 3,
     message: messages.rejected,
     description: "when an amperand precedes a class",
+  }, {
+    code: `
+      .foo {
+        &bar {
+          & .class {}
+        }
+      }
+    `,
+    line: 4,
+    message: messages.rejected,
+    description: "when an ampersand is used to combine two parts of a classname and an amperand precedes a class",
+  }, {
+    code: `
+      p {
+        & span .class {}
+      }
+    `,
+    line: 3,
+    message: messages.rejected,
+    description: "when an amperand precedes an element and a class",
+  }, {
+    code: `
+      p {
+        & span > .class {}
+      }
+    `,
+    line: 3,
+    message: messages.rejected,
+    description: "when an amperand precedes an element, a child selector and a class",
+  }, {
+    code: `
+      p {
+        & + .foo {}
+      }
+    `,
+    line: 3,
+    message: messages.rejected,
+    description: "when an ampersand precedes a sibling operator",
+  }, {
+    code: `
+      p {
+        & ~ .foo {}
+      }
+    `,
+    line: 3,
+    message: messages.rejected,
+    description: "when an ampersand precedes a sibling operator",
   }, {
     code: `
       p {
@@ -153,5 +223,14 @@ testRule(rule, {
     line: 3,
     message: messages.rejected,
     description: "when an ampersand is used by itself",
+  }, {
+    code: `
+      p {
+          &   {}
+      }
+    `,
+    line: 3,
+    message: messages.rejected,
+    description: "when an ampersand is used by itself and there are extra spaces",
   } ],
 })

--- a/src/rules/selector-no-redundant-nesting-selector/index.js
+++ b/src/rules/selector-no-redundant-nesting-selector/index.js
@@ -11,10 +11,12 @@ export default function (actual) {
     const validOptions = utils.validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
-    root.walkRules(rule => {
-      const unnecessaryAmpersandRegex = /^&(\s+)?>?(\s+)?(\w+|\s\.)/
+    root.walkRules(/&/, rule => {
+      const { selector } = rule
+      const combinatorRegex = /^&\s*(>|\+|~)\s*\.*[a-zA-Z]+/
+      const classOrElementRegex = /^&\s+\.*[a-zA-Z]+/
 
-      if (rule.selector.trim() === "&" || unnecessaryAmpersandRegex.test(rule.selector.trim())) {
+      if (selector === "&" || classOrElementRegex.test(selector) || combinatorRegex.test(selector)) {
         utils.report({
           ruleName,
           result,


### PR DESCRIPTION
Fix false positives when `&` is used to combine classname from multiple parts or when BEM syntax is used.