### PR TITLE
Fix severity not working because ruleName is not prefixed, fixes #33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added: `at-import-no-partial-extension` rule.
 - Added: `percent-placeholder-pattern` rule.
 - Fixed: `selector-no-redundant-nesting-selector` no longer warns about BEM syntax.
+- Fixed: bug causing rules to ignore severity levels `warning` / `error` and report `ignore` instead.
 
 # 1.0.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,5 +20,5 @@ We communicate via [issues](https://github.com/kristerkari/stylelint-scss/issues
 stylelint-scss is a plugin for stylelint, so it adopts and uses as much of stylelint's guidelines as it can.
 
 * [Contributing guidelines] (https://github.com/stylelint/stylelint/blob/master/CONTRIBUTING.md) - is a general guidelines of how to communicate with the other developers here.
-* [Working on rules] (https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md). stylelint-scss' rules are written just as stylelint's rules.
+* [Working on rules] (https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md). stylelint-scss' rules are written just as stylelint's rules, except that all rules need to be namespaced using the `namespace` utility function.
 * [Testing rules] (https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rule-testers.md) | [Running tests](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#running-tests). Always provide as many tests as you can.

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
 import { createPlugin } from "stylelint"
+import { namespace } from "./utils"
 import rules from "./rules"
 
-const namespace = "scss"
-
 const rulesPlugins = Object.keys(rules).map(ruleName => {
-  return createPlugin(`${namespace}/${ruleName}`, rules[ruleName])
+  return createPlugin(namespace(ruleName), rules[ruleName])
 })
 
 export default rulesPlugins

--- a/src/rules/at-extend-no-missing-placeholder/index.js
+++ b/src/rules/at-extend-no-missing-placeholder/index.js
@@ -1,6 +1,7 @@
 import { utils } from "stylelint"
+import { namespace } from "../../utils"
 
-export const ruleName = "at-extend-no-missing-placeholder"
+export const ruleName = namespace("at-extend-no-missing-placeholder")
 
 export const messages = utils.ruleMessages(ruleName, {
   rejected: "Expected a placeholder selector (e.g. %placeholder) to be used in @extend",

--- a/src/rules/at-function-pattern/index.js
+++ b/src/rules/at-function-pattern/index.js
@@ -1,7 +1,8 @@
 import { isRegExp, isString } from "lodash"
 import { utils } from "stylelint"
+import { namespace } from "../../utils"
 
-export const ruleName = "at-function-pattern"
+export const ruleName = namespace("at-function-pattern")
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected @function name to match specified pattern",

--- a/src/rules/at-import-no-partial-extension/index.js
+++ b/src/rules/at-import-no-partial-extension/index.js
@@ -1,8 +1,9 @@
 import { isRegExp, isString } from "lodash"
 import { utils } from "stylelint"
+import { namespace } from "../../utils"
 import nodeJsPath from "path"
 
-export const ruleName = "at-import-no-partial-extension"
+export const ruleName = namespace("at-import-no-partial-extension")
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Unexpected file extension in imported partial name",
@@ -38,7 +39,7 @@ export default function (on, options) {
       ) {
         return
       }
-      
+
       if (options && options.ignoreExtensions) {
         // Return if...
         if (options.ignoreExtensions.some(ignoredExt => {

--- a/src/rules/at-import-no-partial-leading-underscore/index.js
+++ b/src/rules/at-import-no-partial-leading-underscore/index.js
@@ -1,6 +1,7 @@
 import { utils } from "stylelint"
+import { namespace } from "../../utils"
 
-export const ruleName = "at-import-no-partial-leading-underscore"
+export const ruleName = namespace("at-import-no-partial-leading-underscore")
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Unexpected leading underscore in imported partial name",

--- a/src/rules/at-mixin-no-argumentless-call-parentheses/index.js
+++ b/src/rules/at-mixin-no-argumentless-call-parentheses/index.js
@@ -1,6 +1,7 @@
 import { utils } from "stylelint"
+import { namespace } from "../../utils"
 
-export const ruleName = "at-mixin-no-argumentless-call-parentheses"
+export const ruleName = namespace("at-mixin-no-argumentless-call-parentheses")
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Unexpected parentheses in argumentless @mixin call",

--- a/src/rules/at-mixin-pattern/index.js
+++ b/src/rules/at-mixin-pattern/index.js
@@ -1,7 +1,8 @@
 import { isRegExp, isString } from "lodash"
 import { utils } from "stylelint"
+import { namespace } from "../../utils"
 
-export const ruleName = "at-mixin-pattern"
+export const ruleName = namespace("at-mixin-pattern")
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected @mixin name to match specified pattern",

--- a/src/rules/dollar-variable-no-missing-interpolation/index.js
+++ b/src/rules/dollar-variable-no-missing-interpolation/index.js
@@ -1,7 +1,8 @@
 import { utils } from "stylelint"
+import { namespace } from "../../utils"
 import valueParser from "postcss-value-parser"
 
-export const ruleName = "dollar-variable-no-missing-interpolation"
+export const ruleName = namespace("dollar-variable-no-missing-interpolation")
 
 export const messages = utils.ruleMessages(ruleName, {
   rejected: (n, v) => `Expected variable ${v} to be interpolated when using it with ${n}`,

--- a/src/rules/dollar-variable-pattern/index.js
+++ b/src/rules/dollar-variable-pattern/index.js
@@ -1,7 +1,8 @@
 import { isRegExp, isString } from "lodash"
 import { utils } from "stylelint"
+import { namespace } from "../../utils"
 
-export const ruleName = "dollar-variable-pattern"
+export const ruleName = namespace("dollar-variable-pattern")
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected $ variable name to match specified pattern",

--- a/src/rules/percent-placeholder-pattern/index.js
+++ b/src/rules/percent-placeholder-pattern/index.js
@@ -6,9 +6,10 @@ import {
   isStandardRule,
   isStandardSelector,
   parseSelector,
+  namespace,
 } from "../../utils"
 
-export const ruleName = "percent-placeholder-pattern"
+export const ruleName = namespace("percent-placeholder-pattern")
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: placeholder => `Expected %-placeholder "%${placeholder}" to match specified pattern`,
@@ -38,7 +39,7 @@ export default function (pattern) {
       if (!isStandardRule(rule)) { return }
       // If the selector has interpolation
       if (!isStandardSelector(selector)) { return }
-      
+
       // Nested selectors are processed in steps, as nesting levels are resolved.
       // Here we skip processing intermediate parts of selectors (to process only fully resolved selectors)
       // if (rule.nodes.some(node => node.type === "rule" || node.type === "atrule")) { return }
@@ -71,4 +72,3 @@ export default function (pattern) {
 
   }
 }
-

--- a/src/rules/selector-no-redundant-nesting-selector/index.js
+++ b/src/rules/selector-no-redundant-nesting-selector/index.js
@@ -1,6 +1,7 @@
 import { utils } from "stylelint"
+import { namespace } from "../../utils"
 
-export const ruleName = "selector-no-redundant-nesting-selector"
+export const ruleName = namespace("selector-no-redundant-nesting-selector")
 
 export const messages = utils.ruleMessages(ruleName, {
   rejected: "Unnecessary nesting selector (&)",

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,3 +2,4 @@ export { default as hasInterpolatingAmpersand } from "./hasInterpolatingAmpersan
 export { default as isStandardRule } from "./isStandardRule"
 export { default as isStandardSelector } from "./isStandardSelector"
 export { default as parseSelector } from "./parseSelector"
+export { default as namespace } from "./namespace"

--- a/src/utils/namespace.js
+++ b/src/utils/namespace.js
@@ -1,0 +1,5 @@
+const prefix = "scss"
+
+export default function namespace(ruleName) {
+  return `${prefix}/${ruleName}`
+}


### PR DESCRIPTION
A quick fix to have stylelint correctly report `error` or `warning` instead of `ignore` for stylelint-scss rules. 

It seems that the plugin name has to match rule's name for everything to work. We have only been namespacing rule names when `createPlugin` gets called, which resulted in bug #33.

Would be nice to know if there is a cleaner way of fixing this than calling `namespace` function in each rule. /CC @davidtheclark @jeddy3 @ntwb @dryoma 