### PR TITLE
New rule: partial-no-import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Added: `partial-no-import` rule.
+
 # 1.1.1
 
 - Fixed: newlines inside braces in `at-function-pattern`, `at-mixin-pattern`.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.
 
 - [`percent-placeholder-pattern`](./src/rules/percent-placeholder-pattern/README.md): Specify a pattern for `%`-placeholders.
 
+### Partial
+
+- [`partial-no-import`](./src/rules/partial-no-import/README.md): Disallow non-CSS `@import`s in partial files.
+
 ### Selector
 
 - [`selector-no-redundant-nesting-selector`](./src/rules/selector-no-redundant-nesting-selector/README.md): Disallow redundant nesting selectors (`&`).

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^2.3.0",
     "eslint-config-stylelint": "^1.0.0",
     "npmpub": "^3.0.3",
+    "postcss": "^5.0.21",
     "postcss-scss": "^0.1.7",
     "replace": "^0.3.0",
     "request": "^2.72.0",

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -6,6 +6,7 @@ import atMixinNoArgumentlessCallParentheses from "./at-mixin-no-argumentless-cal
 import atMixinPattern from "./at-mixin-pattern"
 import dollarVariableNoMissingInterpolation from "./dollar-variable-no-missing-interpolation"
 import dollarVariablePattern from "./dollar-variable-pattern"
+import partialNoImport from "./partial-no-import"
 import percentPlaceholderPattern from "./percent-placeholder-pattern"
 import selectorNoRedundantNestingSelector from "./selector-no-redundant-nesting-selector"
 
@@ -19,5 +20,6 @@ export default {
   "dollar-variable-no-missing-interpolation": dollarVariableNoMissingInterpolation,
   "dollar-variable-pattern": dollarVariablePattern,
   "percent-placeholder-pattern": percentPlaceholderPattern,
+  "partial-no-import": partialNoImport,
   "selector-no-redundant-nesting-selector": selectorNoRedundantNestingSelector,
 }

--- a/src/rules/partial-no-import/README.md
+++ b/src/rules/partial-no-import/README.md
@@ -1,0 +1,69 @@
+# partial-no-import
+
+Disallow non-CSS `@import`s in partial files.
+
+```scss
+// path/to/_file.scss:
+/*         ↑ in partial files */
+
+  @import "path/to/file.scss"
+/*↑ Disallow imports */
+```
+
+The rule skips CSS files (doesn't report any `@import`s in them).
+
+The rule also ignores [cases](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import) when Sass considers an `@import` command just a plain CSS import:
+
+* If the file’s extension is `.css`.
+* If the filename begins with `http://` (or any other protocol).
+* If the filename is a `url()`.
+* If the `@import` has any media queries.
+
+The following patterns are considered warnings:
+
+```scss
+// path/to/_file.scss:
+
+@import "foo.scss";
+```
+
+```scss
+// path/to/_file.less:
+@import "path/fff.less";
+```
+
+```scss
+// path/to/_file.scss:
+@import "path\\fff.supa";
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+// path/to/file.scss:
+@import "path/fff";
+
+/* @import in a file that is not a partial */
+```
+
+```scss
+// path/to/_file.scss:
+@import url("path/_file.css"); /* has url(), so doesn't count as a partial @import */
+```
+
+```scss
+// path/to/_file.scss:
+@import "file.css"; /* Has ".css" extension, so doesn't count as a partial @import */
+```
+
+```scss
+// path/to/_file.scss:
+@import "http://_file.scss";
+@import "//_file.scss";
+/* Both are URIs, so don't count as partial @imports */
+```
+
+```scss
+// path/to/_file.scss:
+@import "file.scss" screen; /* Has a media query, so doesn't count as a partial @import */
+```

--- a/src/rules/partial-no-import/__tests__/index.js
+++ b/src/rules/partial-no-import/__tests__/index.js
@@ -1,0 +1,101 @@
+import rule from ".."
+import postcss from "postcss"
+import path from "path"
+import test from "tape"
+
+test("Import a file from non-partial .scss", t => {
+  t.plan(1)
+  postcss([rule()])
+    .process("@import 'file.scss';", {
+      from: path.join(__dirname, "test.scss"),
+    })
+    .then(result => {
+      const warnings = result.warnings()
+      t.equal(warnings.length, 0, "No warning")
+    })
+})
+
+test("Import a file from a partial .scss", t => {
+  t.plan(1)
+  postcss([rule()])
+    .process("@import 'file.scss';", {
+      from: path.join(__dirname, "_test.scss"),
+    })
+    .then(result => {
+      const warnings = result.warnings()
+      t.equal(warnings.length, 1, "a warning")
+    })
+})
+
+test("Import a file from a partial .scss; omitting extension", t => {
+  t.plan(1)
+  postcss([rule()])
+    .process("@import 'file';", {
+      from: path.join(__dirname, "_test.scss"),
+    })
+    .then(result => {
+      const warnings = result.warnings()
+      t.equal(warnings.length, 1, "a warning")
+    })
+})
+
+// Exceptions
+test("Import a file from CSS", t => {
+  t.plan(1)
+  postcss([rule()])
+    .process("@import 'file.scss';", {
+      from: path.join(__dirname, "_test.css"),
+    })
+    .then(result => {
+      const warnings = result.warnings()
+      t.equal(warnings.length, 0, "Skipping")
+    })
+})
+
+test("Import a CSS from a partial .scss", t => {
+  t.plan(1)
+  postcss([rule()])
+    .process("@import 'file.css';", {
+      from: path.join(__dirname, "_test.scss"),
+    })
+    .then(result => {
+      const warnings = result.warnings()
+      t.equal(warnings.length, 0, "Skipping")
+    })
+})
+
+test("Import a CSS (url) from a partial .scss", t => {
+  t.plan(1)
+  postcss([rule()])
+    .process("@import url('file.scss');", {
+      from: path.join(__dirname, "_test.scss"),
+    })
+    .then(result => {
+      const warnings = result.warnings()
+      t.equal(warnings.length, 0, "Skipping")
+    })
+})
+
+test("Import a CSS (with protocol) from a partial .scss", t => {
+  t.plan(1)
+  postcss([rule()])
+    .process("@import //file.scss;", {
+      from: path.join(__dirname, "_test.scss"),
+    })
+    .then(result => {
+      const warnings = result.warnings()
+      t.equal(warnings.length, 0, "Skipping")
+    })
+})
+
+test("Import a CSS (with media) from a partial .scss", t => {
+  t.plan(1)
+  postcss([rule()])
+    .process("@import file.scss screen", {
+      from: path.join(__dirname, "_test.scss"),
+    })
+    .then(result => {
+      const warnings = result.warnings()
+      t.equal(warnings.length, 0, "Skipping")
+    })
+})

--- a/src/rules/partial-no-import/index.js
+++ b/src/rules/partial-no-import/index.js
@@ -1,0 +1,55 @@
+import { utils } from "stylelint"
+import { namespace } from "../../utils"
+import nodeJsPath from "path"
+
+export const ruleName = namespace("partial-no-import")
+
+export const messages = utils.ruleMessages(ruleName, {
+  expected: "Unexpected @import in a partial",
+})
+
+export default function (on) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: on,
+    })
+    if (!validOptions) { return }
+
+    const fileName = nodeJsPath.basename(root.source.input.file)
+    const extName = nodeJsPath.extname(root.source.input.file)
+
+    function checkImportForCSS(path, decl) {
+      // Stripping trailing quotes and whitespaces, if any
+      const pathStripped = path.replace(/^\s*?("|')\s*/, "").replace(/\s*("|')\s*?$/, "")
+
+      // Skipping importing CSS: url(), ".css", URI with a protocol, media
+      if (pathStripped.slice(0, 4) === "url(" ||
+        pathStripped.slice(-4) === ".css" ||
+        pathStripped.search("//") !== -1 ||
+        pathStripped.search(/(?:\s|[,)"'])\w+$/) !== -1
+      ) {
+        return
+      }
+
+      utils.report({
+        message: messages.expected,
+        node: decl,
+        result,
+        ruleName,
+      })
+    }
+
+    // Usual CSS file
+    if (extName === ".css") { return }
+    // Not a partial
+    if (fileName[0] !== "_") { return }
+
+    root.walkAtRules("import", decl => {
+      // Check if @import is treated as CSS import; report only if not
+      // Processing comma-separated lists of import paths
+      decl.params.split(",").forEach(path => {
+        checkImportForCSS(path, decl)
+      })
+    })
+  }
+}


### PR DESCRIPTION
Implements #28 

Decided to change the name since it is partials that seem to be the *thing* (tha THIIIING!) here, not imports.

Was also happy to be able to peep a test example (not only scss code, but filenames have to be checked here) in stylelint repo :)