### PR TITLE
New rules: at-import-partial-extension-blacklist, at-import-partial-extension-whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added: `media-feature-value-dollar-variable` rule.
 - Added: `at-import-partial-extension-blacklist` rule.
 - Added: `at-import-partial-extension-whitelist` rule.
+- Deprecated: `at-import-no-partial-extension` rule.
 
 # 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added: `partial-no-import` rule.
 - Added: `media-feature-value-dollar-variable` rule.
 - Added: `at-import-partial-extension-blacklist` rule.
+- Added: `at-import-partial-extension-whitelist` rule.
 
 # 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: `partial-no-import` rule.
 - Added: `media-feature-value-dollar-variable` rule.
+- Added: `at-import-partial-extension-blacklist` rule.
 
 # 1.1.1
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.
 
 - [`at-import-no-partial-extension`](./src/rules/at-import-no-partial-extension/README.md): Disallow file extensions in partial names in `@import`.
 - [`at-import-no-partial-leading-underscore`](./src/rules/at-import-no-partial-leading-underscore/README.md): Disallow leading underscore in partial names in `@import`.
+- [`at-import-partial-extension-blacklist`](./src/rules/at-import-partial-extension-blacklist/README.md): Specify blacklist of disallowed file extensions for partial names in `@import` commands.
 
 ### `@`-mixin
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.
 - [`at-import-no-partial-extension`](./src/rules/at-import-no-partial-extension/README.md): Disallow file extensions in partial names in `@import`.
 - [`at-import-no-partial-leading-underscore`](./src/rules/at-import-no-partial-leading-underscore/README.md): Disallow leading underscore in partial names in `@import`.
 - [`at-import-partial-extension-blacklist`](./src/rules/at-import-partial-extension-blacklist/README.md): Specify blacklist of disallowed file extensions for partial names in `@import` commands.
+- [`at-import-partial-extension-whitelist`](./src/rules/at-import-partial-extension-whitelist/README.md): Specify whitelist of allowed file extensions for partial names in `@import` commands.
 
 ### `@`-mixin
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.
 
 ### `@`-import
 
-- [`at-import-no-partial-extension`](./src/rules/at-import-no-partial-extension/README.md): Disallow file extensions in partial names in `@import`.
 - [`at-import-no-partial-leading-underscore`](./src/rules/at-import-no-partial-leading-underscore/README.md): Disallow leading underscore in partial names in `@import`.
 - [`at-import-partial-extension-blacklist`](./src/rules/at-import-partial-extension-blacklist/README.md): Specify blacklist of disallowed file extensions for partial names in `@import` commands.
 - [`at-import-partial-extension-whitelist`](./src/rules/at-import-partial-extension-whitelist/README.md): Specify whitelist of allowed file extensions for partial names in `@import` commands.

--- a/src/rules/at-extend-no-missing-placeholder/README.md
+++ b/src/rules/at-extend-no-missing-placeholder/README.md
@@ -9,8 +9,8 @@ See [Mastering Sass extends and placeholders](http://8gramgorilla.com/mastering-
 ```scss
 .foo {
   @extend %bar
-       // ↑
-       // This is a placeholder selector
+//        ↑
+// This is a placeholder selector
 }
 ```
 

--- a/src/rules/at-import-no-partial-extension/README.md
+++ b/src/rules/at-import-no-partial-extension/README.md
@@ -2,6 +2,8 @@
 
 Disallow file extensions in partial names in `@import`.
 
+**Deprecated. Use [`at-import-partial-extension-blacklist`](/src/rules/at-import-partial-extension-blacklist/README.md) or [`at-import-partial-extension-whitelist`](/src/rules/at-import-partial-extension-whitelist/README.md) instead**
+
 ```scss
 @import "path/to/file.scss"
 /**                  ↑

--- a/src/rules/at-import-no-partial-extension/README.md
+++ b/src/rules/at-import-no-partial-extension/README.md
@@ -7,7 +7,7 @@ Disallow file extensions in partial names in `@import`.
 ```scss
 @import "path/to/file.scss"
 /**                  ↑
- *                   Disallow this */
+ *       Disallow this */
 ```
 
 The rule ignores [cases](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import) when Sass considers an `@import` command just a plain CSS import:

--- a/src/rules/at-import-no-partial-extension/__tests__/index.js
+++ b/src/rules/at-import-no-partial-extension/__tests__/index.js
@@ -1,7 +1,17 @@
-import testRule from "stylelint-test-rule-tape"
-import rule, { ruleName, messages } from ".."
+// Commented out stuff is to prevent tests failing due to a deprecated warning message
+// If something needs tested, uncomment these and comment the warning in the rule code
 
-// Testing main value
+// import testRule from "stylelint-test-rule-tape"
+import rule/* , { ruleName, messages } */ from ".."
+
+import postcss from "postcss"
+import test from "tape"
+
+function logError(err) {
+  console.log(err.stack) // eslint-disable-line no-console
+}
+
+/* // Testing main value
 testRule(rule, {
   ruleName,
   config: [true],
@@ -210,4 +220,20 @@ testRule(rule, {
     message: messages.expected,
     description: "One file, extension differs from the pattern.",
   }],
+}) */
+
+// Test that consider the deprecation warning
+test("Test that considers the deprecation warning", t => {
+
+  t.plan(4)
+  postcss([rule()])
+    .process("@import 'fff.less';")
+    .then(result => {
+      const warnings = result.warnings()
+      t.equal(warnings.length, 2)
+      t.equal(warnings[0].text, "The 'at-import-no-partial-extension' rule has been deprecated, and will be removed in '2.0'. Instead, use 'at-import-partial-extension-blacklist' or 'at-import-partial-extension-whitelist' rules.")
+      t.equal(warnings[0].stylelintType, "deprecation")
+      t.equal(warnings[1].text, "Unexpected file extension in imported partial name (scss/at-import-no-partial-extension)")
+    })
+    .catch(logError)
 })

--- a/src/rules/at-import-no-partial-extension/index.js
+++ b/src/rules/at-import-no-partial-extension/index.js
@@ -43,7 +43,7 @@ export default function (on, options) {
       if (options && options.ignoreExtensions) {
         // Return if...
         if (options.ignoreExtensions.some(ignoredExt => {
-          // the extension matches on of the ignored strings or Regexps
+          // the extension matches one of the ignored strings or Regexps
           return isString(ignoredExt) && ignoredExt === extension ||
             isRegExp(ignoredExt) && extension.search(ignoredExt) !== -1
         })) { return }
@@ -57,10 +57,10 @@ export default function (on, options) {
       })
     }
 
-    root.walkAtRules("import", decl => {
+    root.walkAtRules("import", atRule => {
       // Processing comma-separated lists of import paths
-      decl.params.split(",").forEach(path => {
-        checkPathForUnderscore(path, decl)
+      atRule.params.split(",").forEach(path => {
+        checkPathForUnderscore(path, atRule)
       })
     })
   }

--- a/src/rules/at-import-no-partial-extension/index.js
+++ b/src/rules/at-import-no-partial-extension/index.js
@@ -23,6 +23,13 @@ export default function (on, options) {
     })
     if (!validOptions) { return }
 
+    result.warn((
+      "The 'at-import-no-partial-extension' rule has been deprecated, "
+        + "and will be removed in '2.0'. Instead, use 'at-import-partial-extension-blacklist' or 'at-import-partial-extension-whitelist' rules."
+    ), {
+      stylelintType: "deprecation",
+    })
+
     function checkPathForUnderscore(path, decl) {
       // Stripping trailing quotes and whitespaces, if any
       const pathStripped = path.replace(/^\s*?("|')\s*/, "").replace(/\s*("|')\s*?$/, "")

--- a/src/rules/at-import-no-partial-leading-underscore/README.md
+++ b/src/rules/at-import-no-partial-leading-underscore/README.md
@@ -5,7 +5,7 @@ Disallow leading underscore in partial names in `@import`.
 ```scss
 @import "path/to/_file"
 /**              ↑
- *               Disallow this */
+ *   Disallow this */
 ```
 
 The rule ignores [cases](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import) when Sass considers an `@import` command just a plain CSS import:

--- a/src/rules/at-import-partial-extension-blacklist/README.md
+++ b/src/rules/at-import-partial-extension-blacklist/README.md
@@ -17,7 +17,7 @@ The rule ignores [cases](http://sass-lang.com/documentation/file.SASS_REFERENCE.
 
 ## Options
 
-`array`: `"["array", "of", "extensions"]`
+`array`: `["array", "of", "extensions"]`
 
 Each value is either a string or a regexp.
 

--- a/src/rules/at-import-partial-extension-blacklist/README.md
+++ b/src/rules/at-import-partial-extension-blacklist/README.md
@@ -3,9 +3,9 @@
 Specify blacklist of disallowed file extensions for partial names in `@import` commands.
 
 ```scss
-@import "path/to/file.scss"
-/**                  ↑
- *                   Blacklist of these */
+@import "file.scss"
+/**           ↑
+ * Blacklist of these */
 ```
 
 The rule ignores [cases](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import) when Sass considers an `@import` command just a plain CSS import:

--- a/src/rules/at-import-partial-extension-blacklist/README.md
+++ b/src/rules/at-import-partial-extension-blacklist/README.md
@@ -1,0 +1,70 @@
+# at-import-partial-extension-blacklist
+
+Specify blacklist of disallowed file extensions for partial names in `@import` commands.
+
+```scss
+@import "path/to/file.scss"
+/**                  ↑
+ *                   Blacklist of these */
+```
+
+The rule ignores [cases](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import) when Sass considers an `@import` command just a plain CSS import:
+
+* If the file’s extension is `.css`.
+* If the filename begins with `http://` (or any other protocol).
+* If the filename is a `url()`.
+* If the `@import` has any media queries.
+
+## Options
+
+`array`: `"["array", "of", "extensions"]`
+
+Each value is either a string or a regexp.
+
+Given:
+
+```js
+["scss", /less/]
+```
+
+The following patterns are considered warnings:
+
+```scss
+@import "foo.scss";
+```
+
+```scss
+@import "path/fff.less";
+```
+
+```scss
+@import "path\\fff.ruthless";
+```
+
+```scss
+@import "df/fff", '1.SCSS';
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@import "path/fff";
+```
+
+```scss
+@import url("path/_file.css"); /* has url(), so doesn't count as a partial @import */
+```
+
+```scss
+@import "file.css"; /* Has ".css" extension, so doesn't count as a partial @import */
+```
+
+```scss
+/* Both are URIs, so don't count as partial @imports */
+@import "http://_file.scss";
+@import "//_file.scss";
+```
+
+```scss
+@import "file.scss" screen; /* Has a media query, so doesn't count as a partial @import */
+```

--- a/src/rules/at-import-partial-extension-blacklist/__tests__/index.js
+++ b/src/rules/at-import-partial-extension-blacklist/__tests__/index.js
@@ -1,0 +1,208 @@
+import testRule from "stylelint-test-rule-tape"
+import rule, { ruleName, messages } from ".."
+
+// Testing single value
+testRule(rule, {
+  ruleName,
+  config: ["scss"],
+  syntax: "scss",
+
+  accept: [ {
+    code: `
+      @import "fff";
+    `,
+    description: "Single file, no extension, double quotes.",
+  }, {
+    code: `
+      @import 'fff';
+    `,
+    description: "Single file, no extension, single quotes.",
+  }, {
+    code: `
+      @import ' fff ';
+    `,
+    description: "Single file, no extension, trailing spaces inside quotes.",
+  }, {
+    code: `
+      @import "fff", "score";
+    `,
+    description: "Two files, no extension, double quotes.",
+  }, {
+    code: `
+      @import url("path/_file.css");
+    `,
+    description: "Import CSS with url().",
+  }, {
+    code: `
+      @import "_file.css";
+    `,
+    description: "Import CSS by extension.",
+  }, {
+    code: `
+      @import "http://_file.scss";
+    `,
+    description: "Import CSS from the web, http://.",
+  }, {
+    code: `
+      @import " https://_file.scss ";
+    `,
+    description: "Import CSS from the web, https://, trailing spaces inside quotes",
+  }, {
+    code: `
+      @import "//_file.scss";
+    `,
+    description: "Import CSS from the web, no protocol.",
+  }, {
+    code: `
+      @import "_file.scss" screen;
+    `,
+    description: "Import CSS (with media queries).",
+  }, {
+    code: `
+      @import "_file.scss"screen;
+    `,
+    description: "Import CSS (with media queries).",
+  }, {
+    code: `
+      @import "_file.scss "screen;
+    `,
+    description: "Import CSS (with media queries), trailing space inside quotes.",
+  }, {
+    code: `
+      @import url(_lol.scss) screen;
+    `,
+    description: "Import CSS (with media queries - url + media).",
+  }, {
+    code: `
+      @import _file.scss tv, screen;
+    `,
+    description: "Import CSS (with media queries - multiple).",
+  }, {
+    code: `
+      @import _file.scss tv,screen;
+    `,
+    description: "Import CSS (with media queries - multiple, no spaces).",
+  } ],
+
+  reject: [ {
+    code: `
+      @import "fff.scss";
+    `,
+    line: 2,
+    column: 20,
+    message: messages.rejected("scss"),
+    description: "One file, ext is blacklisted.",
+  }, {
+    code: `
+      @import "fff.scss ";
+    `,
+    line: 2,
+    column: 20,
+    message: messages.rejected("scss"),
+    description: "One file, has extension, space at the end.",
+  }, {
+    code: `
+      @import " fff.scss ";
+    `,
+    line: 2,
+    column: 21,
+    message: messages.rejected("scss"),
+    description: "One file, has extension, trailing spaces.",
+  }, {
+    code: `
+      @import "df/fff.scss";
+    `,
+    line: 2,
+    column: 23,
+    message: messages.rejected("scss"),
+    description: "One file, path with dir, has extension.",
+  }, {
+    code: `
+      @import "df\\fff.scss";
+    `,
+    line: 2,
+    column: 23,
+    message: messages.rejected("scss"),
+    description: "One file, path with dir, has extension, windows delimiters.",
+  }, {
+    code: `
+      @import "df/fff", '_1.scss';
+    `,
+    line: 2,
+    column: 29,
+    message: messages.rejected("scss"),
+    description: "Two files, path with dir, has extension.",
+  } ],
+})
+
+// Testing an array
+testRule(rule, {
+  ruleName,
+  config: [[ "scss", /less/ ]],
+  syntax: "scss",
+
+  accept: [ {
+    code: `
+      @import "fff";
+    `,
+    description: "Single file, no extension.",
+  }, {
+    code: `
+      @import "fff.foo";
+    `,
+    description: "Single file, extension not from a blacklist.",
+  }, {
+    code: `
+      @import " fff.scss1 ";
+    `,
+    description: "Single file, extension not from a blacklist, trailing whitespaces.",
+  }, {
+    code: `
+      @import "fff", "fff.moi";
+    `,
+    description: "Multiple files, ext not from a blacklist.",
+  } ],
+
+  reject: [ {
+    code: `
+      @import "fff.scss";
+    `,
+    line: 2,
+    column: 20,
+    message: messages.rejected("scss"),
+    description: "One file, ext from a blacklist array.",
+  }, {
+    code: `
+      @import "fff.SCsS";
+    `,
+    line: 2,
+    column: 20,
+    message: messages.rejected("SCsS"),
+    description: "One file, ext from a blacklist array, messed case.",
+  }, {
+    code: `
+      @import "fff.less";
+    `,
+    line: 2,
+    column: 20,
+    message: messages.rejected("less"),
+    description: "One file, ext from a blacklist array #2 (regex).",
+  }, {
+    code: `
+      @import "fff.LESS";
+    `,
+    line: 2,
+    column: 20,
+    message: messages.rejected("LESS"),
+    description: "One file, ext from a blacklist array #2 (regex), messed case.",
+  }, {
+    code: `
+      @import "fff",
+          "fff.ruthless";
+    `,
+    line: 3,
+    column: 16,
+    message: messages.rejected("ruthless"),
+    description: "Multiple files, ext from a blacklist array.",
+  } ],
+})

--- a/src/rules/at-import-partial-extension-blacklist/index.js
+++ b/src/rules/at-import-partial-extension-blacklist/index.js
@@ -1,0 +1,62 @@
+import { isRegExp, isString } from "lodash"
+import { utils } from "stylelint"
+import { namespace } from "../../utils"
+import nodeJsPath from "path"
+
+export const ruleName = namespace("at-import-partial-extension-blacklist")
+
+export const messages = utils.ruleMessages(ruleName, {
+  rejected: (ext) => `Unexpected extension ".${ext}" in imported partial name`,
+})
+
+export default function (blacklistOption) {
+  const blacklist = [].concat(blacklistOption)
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: blacklistOption,
+      possible: [ isString, isRegExp ],
+    })
+    if (!validOptions) { return }
+
+    function checkPathForUnderscore(path, decl) {
+      // Stripping trailing quotes and whitespaces, if any
+      const pathStripped = path.replace(/^\s*?("|')\s*/, "").replace(/\s*("|')\s*?$/, "")
+      const extension = nodeJsPath.extname(pathStripped).slice(1)
+      // Save this separately to be able to pass the original string to report()
+      const extensionNormalized = extension.toLowerCase()
+
+      // If the extension is empty
+      if (!extension) { return }
+
+      // Skipping importing CSS: url(), ".css", URI with a protocol, media
+      if (pathStripped.slice(0, 4) === "url(" ||
+        pathStripped.slice(-4) === ".css" ||
+        pathStripped.search("//") !== -1 ||
+        pathStripped.search(/(?:\s|[,)"'])\w+$/) !== -1
+      ) {
+        return
+      }
+
+      blacklist.forEach(ext => {
+        if (isString(ext) && extensionNormalized === ext ||
+          isRegExp(ext) && extensionNormalized.search(ext) !== -1
+        ) {
+          utils.report({
+            message: messages.rejected(extension),
+            node: decl,
+            word: extension,
+            result,
+            ruleName,
+          })
+        }
+      })
+    }
+
+    root.walkAtRules("import", atRule => {
+      // Processing comma-separated lists of import paths
+      atRule.params.split(",").forEach(path => {
+        checkPathForUnderscore(path, atRule)
+      })
+    })
+  }
+}

--- a/src/rules/at-import-partial-extension-whitelist/README.md
+++ b/src/rules/at-import-partial-extension-whitelist/README.md
@@ -17,7 +17,7 @@ The rule ignores [cases](http://sass-lang.com/documentation/file.SASS_REFERENCE.
 
 ## Options
 
-`array`: `"["array", "of", "extensions"]`
+`array`: `["array", "of", "extensions"]`
 
 Each value is either a string or a regexp.
 

--- a/src/rules/at-import-partial-extension-whitelist/README.md
+++ b/src/rules/at-import-partial-extension-whitelist/README.md
@@ -3,9 +3,9 @@
 Specify whitelist of allowed file extensions for partial names in `@import` commands.
 
 ```scss
-@import "path/to/file.scss"
-/**                  ↑
- *                   Blacklist of these */
+@import "file.scss"
+/**           ↑
+ * Blacklist of these */
 ```
 
 The rule ignores [cases](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import) when Sass considers an `@import` command just a plain CSS import:

--- a/src/rules/at-import-partial-extension-whitelist/README.md
+++ b/src/rules/at-import-partial-extension-whitelist/README.md
@@ -1,0 +1,78 @@
+# at-import-partial-extension-whitelist
+
+Specify whitelist of allowed file extensions for partial names in `@import` commands.
+
+```scss
+@import "path/to/file.scss"
+/**                  ↑
+ *                   Blacklist of these */
+```
+
+The rule ignores [cases](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import) when Sass considers an `@import` command just a plain CSS import:
+
+* If the file’s extension is `.css`.
+* If the filename begins with `http://` (or any other protocol).
+* If the filename is a `url()`.
+* If the `@import` has any media queries.
+
+## Options
+
+`array`: `"["array", "of", "extensions"]`
+
+Each value is either a string or a regexp.
+
+Given:
+
+```js
+["scss", /less/]
+```
+
+The following patterns are considered warnings:
+
+```scss
+@import "file.sass";
+```
+
+```scss
+@import "file1", "file.stylus";
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@import "path/fff";
+```
+
+```scss
+@import "foo.scss";
+```
+
+```scss
+@import "path/fff.less";
+```
+
+```scss
+@import "path\\fff.ruthless";
+```
+
+```scss
+@import "df/fff", '1.SCSS';
+```
+
+```scss
+@import url("path/_file.css"); /* has url(), so doesn't count as a partial @import */
+```
+
+```scss
+@import "file.css"; /* Has ".css" extension, so doesn't count as a partial @import */
+```
+
+```scss
+/* Both are URIs, so don't count as partial @imports */
+@import "http://_file.scss";
+@import "//_file.scss";
+```
+
+```scss
+@import "file.scss" screen; /* Has a media query, so doesn't count as a partial @import */
+```

--- a/src/rules/at-import-partial-extension-whitelist/__tests__/index.js
+++ b/src/rules/at-import-partial-extension-whitelist/__tests__/index.js
@@ -1,0 +1,231 @@
+import testRule from "stylelint-test-rule-tape"
+import rule, { ruleName, messages } from ".."
+
+// Testing single value
+testRule(rule, {
+  ruleName,
+  config: ["scss"],
+  syntax: "scss",
+
+  accept: [ {
+    code: `
+      @import "fff";
+    `,
+    description: "Single file, no extension, double quotes.",
+  }, {
+    code: `
+      @import 'fff';
+    `,
+    description: "Single file, no extension, single quotes.",
+  }, {
+    code: `
+      @import ' fff ';
+    `,
+    description: "Single file, no extension, trailing spaces inside quotes.",
+  }, {
+    code: `
+      @import "fff", "score";
+    `,
+    description: "Two files, no extension, double quotes.",
+  }, {
+    code: `
+      @import "fff.scss ";
+    `,
+    description: "One file, whitelisted extension, space at the end.",
+  }, {
+    code: `
+      @import " fff.scss ";
+    `,
+    description: "One file, whitelisted extension, trailing spaces.",
+  }, {
+    code: `
+      @import "df/fff.scss";
+    `,
+    description: "One file, path with dir, whitelisted extension.",
+  }, {
+    code: `
+      @import "df\\fff.scss";
+    `,
+    description: "One file, path with dir, whitelisted extension, windows delimiters.",
+  }, {
+    code: `
+      @import "df/fff", '_1.scss';
+    `,
+    description: "Two files, path with dir, whitelisted extension.",
+  } ],
+
+  reject: [ {
+    code: `
+      @import "fff.less";
+    `,
+    line: 2,
+    column: 20,
+    message: messages.rejected("less"),
+    description: "One file, ext not from a whitelist-string.",
+  }, {
+    code: `
+      @import "fff.scssy ";
+    `,
+    line: 2,
+    column: 20,
+    message: messages.rejected("scssy"),
+    description: "One file, ext not from a whitelist-string, space at the end.",
+  }, {
+    code: `
+      @import " fff.less ";
+    `,
+    line: 2,
+    column: 21,
+    message: messages.rejected("less"),
+    description: "One file, ext not from a whitelist-string, trailing spaces.",
+  }, {
+    code: `
+      @import "df/fff.less";
+    `,
+    line: 2,
+    column: 23,
+    message: messages.rejected("less"),
+    description: "One file, path with dir, ext not from a whitelist-string.",
+  }, {
+    code: `
+      @import "df\\fff.less";
+    `,
+    line: 2,
+    column: 23,
+    message: messages.rejected("less"),
+    description: "One file, path with dir, ext not from a whitelist-string, windows delimiters.",
+  }, {
+    code: `
+      @import "df/fff", '_1.less';
+    `,
+    line: 2,
+    column: 29,
+    message: messages.rejected("less"),
+    description: "Two files, path with dir, ext not from a whitelist-string.",
+  } ],
+})
+
+// Testing exceptions
+testRule(rule, {
+  ruleName,
+  config: ["scss"],
+  syntax: "scss",
+
+  accept: [ {
+    code: `
+      @import url("path/_file.css");
+    `,
+    description: "Import CSS with url().",
+  }, {
+    code: `
+      @import "_file.css";
+    `,
+    description: "Import CSS by extension.",
+  }, {
+    code: `
+      @import "http://_file.scss";
+    `,
+    description: "Import CSS from the web, http://.",
+  }, {
+    code: `
+      @import " https://_file.scss ";
+    `,
+    description: "Import CSS from the web, https://, trailing spaces inside quotes",
+  }, {
+    code: `
+      @import "//_file.scss";
+    `,
+    description: "Import CSS from the web, no protocol.",
+  }, {
+    code: `
+      @import "_file.scss" screen;
+    `,
+    description: "Import CSS (with media queries).",
+  }, {
+    code: `
+      @import "_file.scss"screen;
+    `,
+    description: "Import CSS (with media queries).",
+  }, {
+    code: `
+      @import "_file.scss "screen;
+    `,
+    description: "Import CSS (with media queries), trailing space inside quotes.",
+  }, {
+    code: `
+      @import url(_lol.scss) screen;
+    `,
+    description: "Import CSS (with media queries - url + media).",
+  }, {
+    code: `
+      @import _file.scss tv, screen;
+    `,
+    description: "Import CSS (with media queries - multiple).",
+  }, {
+    code: `
+      @import _file.scss tv,screen;
+    `,
+    description: "Import CSS (with media queries - multiple, no spaces).",
+  } ],
+})
+
+// Testing an array
+testRule(rule, {
+  ruleName,
+  config: [[ "scss", /less/ ]],
+  syntax: "scss",
+
+  accept: [ {
+    code: `
+      @import "fff.scss";
+    `,
+    description: "One file, ext from a whitelist array (string).",
+  }, {
+    code: `
+      @import "fff.SCsS";
+    `,
+    description: "One file, ext from a whitelist array (string), messed case.",
+  }, {
+    code: `
+      @import "fff.less";
+    `,
+    description: "One file, ext from a whitelist array (regex).",
+  }, {
+    code: `
+      @import "fff.LESS";
+    `,
+    description: "One file, ext from a whitelist array (regex), messed case.",
+  }, {
+    code: `
+      @import "fff",
+          "fff.ruthless";
+    `,
+    description: "Multiple files, ext from a whitelist array (regex), partial match.",
+  } ],
+
+  reject: [ {
+    code: `
+      @import "fff.foo";
+    `,
+    line: 2,
+    column: 20,
+    message: messages.rejected("foo"),
+    description: "Single file, extension not from a whitelist.",
+  }, {
+    code: `
+      @import " fff.scss1 ";
+    `,
+    line: 2,
+    column: 21,
+    message: messages.rejected("scss1"),
+    description: "Single file, extension not from a whitelist, trailing whitespaces.",
+  }, {
+    code: `
+      @import "fff", "fff.moi";
+    `,
+    line: 2,
+    column: 27,
+    message: messages.rejected("moi"),
+    description: "Multiple files, ext not from a whitelist.",
+  } ],
+})

--- a/src/rules/at-import-partial-extension-whitelist/index.js
+++ b/src/rules/at-import-partial-extension-whitelist/index.js
@@ -1,0 +1,61 @@
+import { isRegExp, isString } from "lodash"
+import { utils } from "stylelint"
+import { namespace } from "../../utils"
+import nodeJsPath from "path"
+
+export const ruleName = namespace("at-import-partial-extension-whitelist")
+
+export const messages = utils.ruleMessages(ruleName, {
+  rejected: (ext) => `Unexpected extension ".${ext}" in imported partial name`,
+})
+
+export default function (whitelistOption) {
+  const whitelist = [].concat(whitelistOption)
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: whitelistOption,
+      possible: [ isString, isRegExp ],
+    })
+    if (!validOptions) { return }
+
+    function checkPathForUnderscore(path, decl) {
+      // Stripping trailing quotes and whitespaces, if any
+      const pathStripped = path.replace(/^\s*?("|')\s*/, "").replace(/\s*("|')\s*?$/, "")
+      const extension = nodeJsPath.extname(pathStripped).slice(1)
+      // Save this separately to be able to pass the original string to report()
+      const extensionNormalized = extension.toLowerCase()
+
+      // If the extension is empty
+      if (!extension) { return }
+
+      // Skipping importing CSS: url(), ".css", URI with a protocol, media
+      if (pathStripped.slice(0, 4) === "url(" ||
+        pathStripped.slice(-4) === ".css" ||
+        pathStripped.search("//") !== -1 ||
+        pathStripped.search(/(?:\s|[,)"'])\w+$/) !== -1
+      ) {
+        return
+      }
+
+      if (whitelist.some(ext => {
+        return isString(ext) && extensionNormalized === ext ||
+          isRegExp(ext) && extensionNormalized.search(ext) !== -1
+      })) { return }
+
+      utils.report({
+        message: messages.rejected(extension),
+        node: decl,
+        word: extension,
+        result,
+        ruleName,
+      })
+    }
+
+    root.walkAtRules("import", atRule => {
+      // Processing comma-separated lists of import paths
+      atRule.params.split(",").forEach(path => {
+        checkPathForUnderscore(path, atRule)
+      })
+    })
+  }
+}

--- a/src/rules/at-mixin-no-argumentless-call-parentheses/README.md
+++ b/src/rules/at-mixin-no-argumentless-call-parentheses/README.md
@@ -5,7 +5,7 @@ Disallow parentheses in argumentless `@mixin` calls.
 ```scss
 @include mixin-name() {
 /**                ↑
- *                 Such mixin calls */
+ *  Such mixin calls */
 ```
 
 The following patterns are considered warnings:

--- a/src/rules/dollar-variable-no-missing-interpolation/README.md
+++ b/src/rules/dollar-variable-no-missing-interpolation/README.md
@@ -6,9 +6,9 @@ Disallow Sass variables that are used without interpolation with CSS features th
 .class {
   $var: "my-anim";
   animation-name: $var;
-              // ↑
-              // This variable needs to be interpolated
-              // because its value is a string
+//                ↑
+// This variable needs to be interpolated
+// because its value is a string
 }
 ```
 

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -3,6 +3,7 @@ import atFunctionPattern from "./at-function-pattern"
 import atImportNoPartialExtension from "./at-import-no-partial-extension"
 import atImportNoPartialLeadingUnderscore from "./at-import-no-partial-leading-underscore"
 import atImportPartialExtensionBlacklist from "./at-import-partial-extension-blacklist"
+import atImportPartialExtensionWhitelist from "./at-import-partial-extension-whitelist"
 import atMixinNoArgumentlessCallParentheses from "./at-mixin-no-argumentless-call-parentheses"
 import atMixinPattern from "./at-mixin-pattern"
 import dollarVariableNoMissingInterpolation from "./dollar-variable-no-missing-interpolation"
@@ -18,6 +19,7 @@ export default {
   "at-import-no-partial-extension": atImportNoPartialExtension,
   "at-import-no-partial-leading-underscore": atImportNoPartialLeadingUnderscore,
   "at-import-partial-extension-blacklist": atImportPartialExtensionBlacklist,
+  "at-import-partial-extension-whitelist": atImportPartialExtensionWhitelist,
   "at-mixin-no-argumentless-call-parentheses": atMixinNoArgumentlessCallParentheses,
   "at-mixin-pattern": atMixinPattern,
   "dollar-variable-no-missing-interpolation": dollarVariableNoMissingInterpolation,

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -2,6 +2,7 @@ import atExtendNoMissingPlaceholder from "./at-extend-no-missing-placeholder"
 import atFunctionPattern from "./at-function-pattern"
 import atImportNoPartialExtension from "./at-import-no-partial-extension"
 import atImportNoPartialLeadingUnderscore from "./at-import-no-partial-leading-underscore"
+import atImportPartialExtensionBlacklist from "./at-import-partial-extension-blacklist"
 import atMixinNoArgumentlessCallParentheses from "./at-mixin-no-argumentless-call-parentheses"
 import atMixinPattern from "./at-mixin-pattern"
 import dollarVariableNoMissingInterpolation from "./dollar-variable-no-missing-interpolation"
@@ -16,6 +17,7 @@ export default {
   "at-function-pattern": atFunctionPattern,
   "at-import-no-partial-extension": atImportNoPartialExtension,
   "at-import-no-partial-leading-underscore": atImportNoPartialLeadingUnderscore,
+  "at-import-partial-extension-blacklist": atImportPartialExtensionBlacklist,
   "at-mixin-no-argumentless-call-parentheses": atMixinNoArgumentlessCallParentheses,
   "at-mixin-pattern": atMixinPattern,
   "dollar-variable-no-missing-interpolation": dollarVariableNoMissingInterpolation,

--- a/src/rules/percent-placeholder-pattern/README.md
+++ b/src/rules/percent-placeholder-pattern/README.md
@@ -3,9 +3,9 @@
 Specify a pattern for `%`-placeholders.
 
 ```scss
-     %foobar { display: flex; }
-/**  ↑
- *   The pattern of this */
+    %foobar { display: flex; }
+/** ↑
+ * The pattern of this */
 ```
 
 ## Options


### PR DESCRIPTION
Implements #41 

Two separate rules for extensions blacklist and whitelist, the old one gets deprecated (and to be removed in 2.0.0).

There is a problem though. Deprecation warning makes all the tests for `at-import-no-partial-extension` fail. Is there a more graceful way of giving such warnings?