### PR TITLE
Fixes dollar-variable-no-missing-interpolation not working with older versions of Node.

### DIFF
--- a/src/rules/dollar-variable-no-missing-interpolation/index.js
+++ b/src/rules/dollar-variable-no-missing-interpolation/index.js
@@ -1,3 +1,4 @@
+import { includes } from "lodash"
 import { utils } from "stylelint"
 import { namespace } from "../../utils"
 import valueParser from "postcss-value-parser"
@@ -30,11 +31,11 @@ function isAtRule(type) {
 }
 
 function isCustomIdentAtRule(node) {
-  return isAtRule(node.type) && customIdentAtRules.includes(node.name)
+  return isAtRule(node.type) && includes(customIdentAtRules, node.name)
 }
 
 function isCustomIdentProp(node) {
-  return customIdentProps.includes(node.prop)
+  return includes(customIdentProps, node.prop)
 }
 
 function isAtSupports(node) {
@@ -65,7 +66,7 @@ export default function (actual) {
       node.walkDecls(decl => {
         const { prop, value } = decl
 
-        if (!isSassVar(prop) || vars.includes(prop)) {
+        if (!isSassVar(prop) || includes(vars, prop)) {
           return
         }
 
@@ -84,10 +85,10 @@ export default function (actual) {
 
     function shouldReport(node, value) {
       if (isAtSupports(node) || isCustomIdentProp(node)) {
-        return stringVars.includes(value)
+        return includes(stringVars, value)
       }
       if (isCustomIdentAtRule(node)) {
-        return vars.includes(value)
+        return includes(vars, value)
       }
       return false
     }


### PR DESCRIPTION
My company is still on Node 4 (I am specifically running, Node 4.2.2 and NPM 2.15.0), and when I tried to use the `dollar-variable-no-missing-interpolation` rule, I received the following exception.

```
TypeError: vars.includes is not a function
    at /Users/Developer/someproject/node_modules/stylelint-scss/dist/rules/dollar-variable-no-missing-interpolation/index.js:24:38
    at /Users/Developer/someproject/node_modules/stylelint/node_modules/postcss/lib/container.js:94:28
    at /Users/Developer/someproject/node_modules/stylelint/node_modules/postcss/lib/container.js:81:26
    at Root.each (/Users/Developer/someproject/node_modules/stylelint/node_modules/postcss/lib/container.js:68:22)
    at Root.walk (/Users/Developer/someproject/node_modules/stylelint/node_modules/postcss/lib/container.js:80:21)
    at Root.walkDecls (/Users/Developer/someproject/node_modules/stylelint/node_modules/postcss/lib/container.js:92:25)
    at findVars (/Users/Developer/someproject/node_modules/stylelint-scss/dist/rules/dollar-variable-no-missing-interpolation/index.js:19:12)
    at /Users/Developer/someproject/node_modules/stylelint-scss/dist/rules/dollar-variable-no-missing-interpolation/index.js:36:5
    at /Users/Developer/someproject/node_modules/stylelint/dist/postcssPlugin.js:131:67
    at Array.forEach (native)
```

This is because the rule was using [Array.prototype.includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), which [only works in Node 5 (with the `--harmony_array_includes` flag) and natively in Node 6](https://github.com/nodejs/node/issues/5715#issuecomment-196745766).

To make this play nicely with Node 5 without the flag, Node 4, and presumably older versions of Node as well, this PR changes `Array.prototype.includes` instances to use [lodash's includes](https://lodash.com/docs#includes) instead.

I have tested this by:

* Running `npm test` locally and all tests pass.
* By creating a new `dist` using `npm run build`, replacing the `dist` in my project with the newly generated `dist`, and the rule works as expected.