### PR TITLE
Rules for //-comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: `at-mixin-argumentless-call-parentheses` rule (with "always"/"never" behavior). Deprecated `at-mixin-no-argumentless-call-parentheses`.
 - Fixed: `partial-no-import` failing when linting a code string (not in an actual file, e.g. via stylelilnt Node API).
+- Added: `double-slash-comment-empty-line-before` rule.
 
 # 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed: `partial-no-import` failing when linting a code string (not in an actual file, e.g. via stylelilnt Node API).
 - Added: `double-slash-comment-empty-line-before` rule.
 - Added: `double-slash-comment-inline` rule.
+- Added: `double-slash-comment-whitespace-inside` rule.
 
 # 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added: `at-mixin-argumentless-call-parentheses` rule (with "always"/"never" behavior). Deprecated `at-mixin-no-argumentless-call-parentheses`.
 - Fixed: `partial-no-import` failing when linting a code string (not in an actual file, e.g. via stylelilnt Node API).
 - Added: `double-slash-comment-empty-line-before` rule.
+- Added: `double-slash-comment-inline` rule.
 
 # 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.
 
 - [`double-slash-comment-empty-line-before`](./src/rules/double-slash-comment-empty-line-before/README.md): Require or disallow an empty line before `//`-comments.
 - [`double-slash-comment-inline`](./src/rules/double-slash-comment-inline/README.md): Require or disallow `//`-comments to be inline comments.
+- [`double-slash-comment-whitespace-inside`](./src/rules/double-slash-comment-whitespace-inside/README.md): Require or disallow whitespace after the `//` in `//`-comments
 
 ### Media feature
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.
 
 - [`percent-placeholder-pattern`](./src/rules/percent-placeholder-pattern/README.md): Specify a pattern for `%`-placeholders.
 
+### `//`-comment
+
+- [`double-slash-comment-empty-line-before`](./src/rules/double-slash-comment-empty-line-before/README.md): Require or disallow an empty line before `//`-comments.
+
 ### Media feature
 
 - [`media-feature-value-dollar-variable`](./src/rules/media-feature-value-dollar-variable/README.md): Require a media feature value be a `$`-variable or disallow `$`-variables in media feature values.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.
 ### `//`-comment
 
 - [`double-slash-comment-empty-line-before`](./src/rules/double-slash-comment-empty-line-before/README.md): Require or disallow an empty line before `//`-comments.
+- [`double-slash-comment-inline`](./src/rules/double-slash-comment-inline/README.md): Require or disallow `//`-comments to be inline comments.
 
 ### Media feature
 

--- a/src/rules/double-slash-comment-empty-line-before/README.md
+++ b/src/rules/double-slash-comment-empty-line-before/README.md
@@ -1,0 +1,149 @@
+# double-slash-comment-empty-line-before
+
+Require or disallow an empty line before `//`-comments.
+
+```scss
+a {}
+           /* ← */
+// comment /* ↑ */
+/**           ↑
+*     This line */
+```
+
+This rule only works with SCSS-like [single-line comments](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#comments) and ignores:
+* comments that are the very first nodes in a file;
+* CSS comments (`/* */`);
+* comments that are on the same line as some non-comment code (inline comments).
+
+## Options
+
+`string`: `"always"|"never"`
+
+### `"always"`
+
+There *must always* be an empty line before `//`-comments.
+
+The following patterns are considered warnings:
+
+```scss
+a {}
+// comment
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+a {}
+
+// comment
+```
+
+```scss
+a {} // comment
+```
+
+### `"never"`
+
+There *must never* be an empty line before `//`-comments.
+
+The following patterns are considered warnings:
+
+```scss
+a {}
+
+// comment
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+a {}
+// comment
+```
+
+```scss
+a {} // comment
+```
+
+## Optional options
+
+### `except: ["first-nested"]`
+
+Reverse the primary option for `//`-comments that are nested and the first child of their parent node.
+
+For example, with `"always"`:
+
+The following patterns are considered warnings:
+
+```scss
+a {
+
+  // comment
+  color: pink;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+a {
+  // comment
+  color: pink;
+}
+```
+
+### `ignore: ["between-comments", "stylelint-commands"]`
+
+#### `"between-comments"`
+
+Don't require an empty line before `//`-comments that are placed after other `//`-comments or CSS comments.
+
+For example, with `"always"`:
+
+The following patterns are *not* considered warnings:
+
+```scss
+a {
+  background: pink;
+
+  // comment
+  // comment
+  color: #eee;
+}
+```
+
+```scss
+a {
+  background: pink;
+
+  /* comment */
+  // comment
+  color: #eee;
+}
+```
+
+#### `"stylelint-commands"`
+
+Ignore `//`-comments that deliver commands to stylelint, e.g. `// stylelint-disable color-no-hex`.
+
+For example, with `"always"`:
+
+The following patterns are considered warnings:
+
+```scss
+a {
+  background: pink;
+  // not a stylelint command
+  color: #eee;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+a {
+  background: pink;
+  // stylelint-disable color-no-hex
+  color: pink;
+}
+```

--- a/src/rules/double-slash-comment-empty-line-before/__tests__/index.js
+++ b/src/rules/double-slash-comment-empty-line-before/__tests__/index.js
@@ -1,0 +1,277 @@
+import testRule from "stylelint-test-rule-tape"
+import rule, { ruleName, messages } from ".."
+
+// Used in all "always" tests
+const alwaysGeneralTests = {
+  accept: [ {
+    code: "// First node, ignored",
+    description: "First node, ignored.",
+  }, {
+    code: `
+      a { color: pink; /* CSS comment */
+      top: 0; }
+    `,
+    description: "CSS comment inside ruleset, ignored.",
+  }, {
+    code: "a {} /* CSS comment */",
+    description: "CSS comment in root scope, ignored.",
+  }, {
+    code: "a {} // Inline comment",
+    description: "Inline comment (on the same line as some code).",
+  }, {
+    code: `
+      a {}
+      
+      // comment with empty line before it
+    `,
+    description: "Proper empty line, root scope.",
+  }, {
+    code: "a {}\r\n\r\n// comment with Win empty line",
+    description: "Proper empty line (Windows style).",
+  }, {
+    code: "a {}\n\r\n// comment with mixed empty line",
+    description: "Proper empty lint (mixed styles).",
+  }, {
+    code: `
+      a { color: pink;
+      
+      // comment with proper empty line
+      top: 0; }
+    `,
+    description: "Proper empty line, inside ruleset.",
+  } ],
+
+  reject: [ {
+    code: `
+      // comment 1
+      // comment 2
+    `,
+    message: messages.expected,
+  }, {
+    code: "// comment\r\n// comment",
+    description: "One windows newline between comments.",
+    message: messages.expected,
+  }, {
+    code: `
+      a { color: pink;
+      // comment w/o empty line
+      top: 0; }
+    `,
+    message: messages.expected,
+  }, {
+    code: "a { color: pink;\r\n// comment w/o empty lines, Win style\r\ntop: 0; }",
+    description: "One Windows newline before comment.",
+    message: messages.expected,
+  } ],
+}
+
+// -------------------------------------------------------------------------
+// "always"
+// -------------------------------------------------------------------------
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: alwaysGeneralTests.accept.concat([{
+    code: `a {
+      
+      // First-nested, empty line before
+      color: pink;
+    }`,
+    description: "First-nested, empty line before.",
+  }]),
+
+  reject: alwaysGeneralTests.reject.concat([{
+    code: `a {
+      // First-nested, no empty line before.
+      color: pink;
+    }`,
+    description: "First-nested, no empty line before.",
+    message: messages.expected,
+    line: 2,
+    column: 7,
+  }]),
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "always", { except: ["first-nested"] } ],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: alwaysGeneralTests.accept.concat([{
+    code: `
+      a {
+        // First nested, now empty line.
+        color: pink;
+      }
+    `,
+    description: "First nested, now empty line.",
+  }]),
+
+  reject: alwaysGeneralTests.reject.concat([{
+    code: `
+      a {
+      
+      // First-nested, with empty line (rejected).
+      color: pink;
+    }`,
+    description: "First-nested, with empty line (rejected).",
+    message: messages.rejected,
+    line: 4,
+    column: 7,
+  }]),
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "always", { ignore: ["stylelint-commands"] } ],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: alwaysGeneralTests.accept.concat([{
+    code: `
+      a {
+        color: pink;
+        // stylelint-disable something 
+        top: 0;
+      }
+    `,
+    description: "stylelint command line-comment, no empty line before (ignored).",
+  }]),
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "always", { ignore: ["between-comments"] } ],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: `
+      // comment 1
+      // comment 2 
+      // comment 3
+      body { color: red; }
+    `,
+    description: "Multiple comments, root level, no emply lines between.",
+  }, {
+    code: `
+      a { color: pink;
+      
+      /// comment 1
+      /// comment 2
+      top: 0;
+    }`,
+    description: "Multiple comments, inside ruleset, empty line only before the 1st.",
+  }, {
+    code: `
+      a { color: pink;
+      
+      /* comment 1 */
+      /// comment 2
+      top: 0;
+    }`,
+    description: "2 comments, 1st is CSS one, 2nd is single-line, empty line only before the 1st.",
+  }, {
+    code: `
+      a { color: pink;
+      
+      /// comment 1
+      /* comment 2 */
+      top: 0;
+    }`,
+    description: "2 comments, 1st is single-line, 2nd is CSS one, empty line only before the 1st.",
+  } ],
+
+  reject: [{
+    code: `
+      a {
+        color: pink;
+        /// comment
+        /// comment
+        top: 0;
+      }
+    `,
+    description: "Multiple comments, inside ruleset, no empty lines.",
+    message: messages.expected,
+  }],
+})
+
+// -------------------------------------------------------------------------
+// "never"
+// -------------------------------------------------------------------------
+
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: `
+      
+      // comment
+    `,
+    description: "First nested, empty line, ignored.",
+  }, {
+    code: "\r\n\r\n// comment",
+    description: "First nested, CRLF-empty line, ignored.",
+  }, {
+    code: `
+      a {
+        color: pink;
+
+        /** CSS comment */
+        top: 0;
+      }
+    `,
+    description: "CSS comment, ignored",
+  }, {
+    code: "a {} // Inline comment",
+  }, {
+    code: `a {
+      color: pink;
+      // comment
+      
+      top: 0;
+    }
+  `,
+  }, {
+    code: "a { color: pink;\r\n// comment\r\n\r\ntop: 0; }",
+    description: "CRLF",
+  } ],
+
+  reject: [ {
+    code: `
+      // comment
+
+      /// comment
+    `,
+    message: messages.rejected,
+  }, {
+    code: `
+      a {}
+
+      // comment
+    `,
+    message: messages.rejected,
+  }, {
+    code: "a {}\r\n\r\n\r\n// comment",
+    description: "CRLF",
+    message: messages.rejected,
+  }, {
+    code: `
+      a {
+        color: pink;
+        
+        // comment
+        top: 0;
+      }
+    `,
+    message: messages.rejected,
+  } ],
+})

--- a/src/rules/double-slash-comment-empty-line-before/__tests__/index.js
+++ b/src/rules/double-slash-comment-empty-line-before/__tests__/index.js
@@ -157,7 +157,7 @@ testRule(rule, {
       // comment 3
       body { color: red; }
     `,
-    description: "Multiple comments, root level, no emply lines between.",
+    description: "Multiple comments, root level, no empty lines between.",
   }, {
     code: `
       a { color: pink;

--- a/src/rules/double-slash-comment-empty-line-before/index.js
+++ b/src/rules/double-slash-comment-empty-line-before/index.js
@@ -1,0 +1,88 @@
+import {
+  isInlineComment,
+  namespace,
+  optionsHaveException,
+  optionsHaveIgnored,
+} from "../../utils"
+import { utils } from "stylelint"
+
+export const ruleName = namespace("double-slash-comment-empty-line-before")
+
+export const messages = utils.ruleMessages(ruleName, {
+  expected: "Expected empty line before comment",
+  rejected: "Unexpected empty line before comment",
+})
+
+const stylelintCommandPrefix = "stylelint-"
+
+export default function (expectation, options) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: [
+        "always",
+        "never",
+      ],
+    }, {
+      actual: options,
+      possible: {
+        except: ["first-nested"],
+        ignore: [
+          "stylelint-commands",
+          "between-comments",
+        ],
+      },
+      optional: true,
+    })
+    if (!validOptions) { return }
+
+    root.walkComments(comment => {
+
+      // Only process // comments
+      if (!comment.raws.inline && !comment.inline) { return }
+      
+      if (isInlineComment(comment)) { return }
+
+      // Ignore the first node
+      if (comment === root.first) { return }
+
+      // Optionally ignore stylelint commands
+      if (
+        comment.text.indexOf(stylelintCommandPrefix) === 0
+        && optionsHaveIgnored(options, "stylelint-commands")
+      ) { return }
+
+      // Optionally ignore newlines between comments
+      const prev = comment.prev()
+      if (
+        prev && prev.type === "comment"
+        && optionsHaveIgnored(options, "between-comments")
+      ) { return }
+
+      const before = comment.raw("before")
+
+      const expectEmptyLineBefore = (() => {
+        if (
+          optionsHaveException(options, "first-nested")
+          && comment.parent !== root
+          && comment === comment.parent.first
+        ) { return false }
+        return expectation === "always"
+      })()
+
+      const hasEmptyLineBefore = before.search(/\n\s*?\n/) !== -1
+
+      // Return if the expectation is met
+      if (expectEmptyLineBefore === hasEmptyLineBefore) { return }
+
+      const message = expectEmptyLineBefore ? messages.expected : messages.rejected
+
+      utils.report({
+        message,
+        node: comment,
+        result,
+        ruleName,
+      })
+    })
+  }
+}

--- a/src/rules/double-slash-comment-inline/README.md
+++ b/src/rules/double-slash-comment-inline/README.md
@@ -1,0 +1,110 @@
+# double-slash-comment-inline
+
+Require or disallow `//`-comments to be inline comments.
+
+```scss
+a {
+  width: 10px; // inline-comment
+/*             ↑
+ * Such comments */
+```
+
+An inline comment in terms of this rule is a comment that is placed on the same line with any other code, either before or after it.
+
+This rule only works with SCSS-like [single-line comments](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#comments) and ignores CSS comments (`/* */`).
+
+## Options
+
+`string`: `"always"|"never"`
+
+### `"always"`
+
+`//`-comments *must always* be inline comments.
+
+The following patterns are considered warnings:
+
+```scss
+// comment
+a { width: 10px; }
+```
+
+```scss
+a {
+  // comment
+  width: 10px;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+a { // comment
+  width: 10px;
+}
+```
+
+```scss
+a {
+  width: 10px; // comment
+}
+```
+
+```scss
+a, // comment
+b {
+  width: 10px;
+}
+```
+
+### `"never"`
+
+`//`-comments *must never* be inline comments.
+
+The following patterns are considered warnings:
+
+```scss
+a {
+  width: 10px; // comment
+}
+```
+
+```scss
+a, // comment
+b {
+  width: 10px;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+// comment
+a { width: 10px; }
+```
+
+```scss
+a {
+  // comment
+  width: 10px;
+}
+```
+
+## Optional options
+
+### `ignore: ["stylelint-commands"]`
+
+#### `"stylelint-commands"`
+
+Ignore `//`-comments that deliver commands to stylelint, e.g. `// stylelint-disable color-no-hex`.
+
+For example, with `"always"`:
+
+The following patterns are *not* considered warnings:
+
+```scss
+a {
+  background: pink;
+  // stylelint-disable color-no-hex
+  color: pink;
+}
+```

--- a/src/rules/double-slash-comment-inline/__tests__/index.js
+++ b/src/rules/double-slash-comment-inline/__tests__/index.js
@@ -1,0 +1,160 @@
+import testRule from "stylelint-test-rule-tape"
+import rule, { ruleName, messages } from ".."
+
+// -------------------------------------------------------------------------
+// "always"
+// -------------------------------------------------------------------------
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "a {} // Inline comment, outside a ruleset.",
+    description: "Inline comment, outside a ruleset.",
+  }, {
+    code: `a { // Inline comment, after {.
+      width: 10px;
+    }`,
+    description: "Inline comment, after {.",
+  }, {
+    code: `
+      a, // Inline comment between selectors.
+      b {
+        width: 10px;
+      }
+    `,
+    description: "Inline comment between selectors.",
+  }, {
+    code: `a {
+      /* Non-inline CSS comment, ignored */
+      width: 10px;
+    }`,
+    description: "Non-inline CSS comment, ignored.",
+  } ],
+
+  reject: [ {
+    code: `
+      a { }
+      // Non-inline comment (after a ruleset)
+    `,
+    description: "Non-inline comment (after a ruleset)",
+    message: messages.expected,
+    line: 3,
+    column: 7,
+  }, {
+    code: `
+      a,
+      // Non-inline comment between selectors
+      b { }
+    `,
+    description: "Non-inline comment between selectors.",
+    message: messages.expected,
+    line: 3,
+    column: 7,
+  }, {
+    code: `
+      a {
+        // Non-inline comment (before a decl)
+        width: 10px;
+      }
+    `,
+    description: "Non-inline comment (before a decl)",
+    message: messages.expected,
+    line: 3,
+    column: 9,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "always", { ignore: ["stylelint-commands"] } ],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: [{
+    code: `
+      a {
+        color: pink;
+        // stylelint-disable something 
+        top: 0;
+      }
+    `,
+    description: "stylelint command non-inline comment.",
+  }],
+})
+
+// -------------------------------------------------------------------------
+// "never"
+// -------------------------------------------------------------------------
+
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: `
+      // comment
+    `,
+    description: "Non-inline comment, outside rulesets.",
+  }, {
+    code: `
+      a { color: red; }
+      // Non-inline comment, outside rulesets.
+    `,
+    description: "Non-inline comment, outside rulesets.",
+  }, {
+    code: `
+      a {
+        color: red; /* Inline CSS comment, ignored */
+      }
+    `,
+    description: "Inline CSS comment, ignored.",
+  } ],
+
+  reject: [ {
+    code: "a {} // comment",
+    message: messages.rejected,
+    description: "Inline comment, outside a ruleset.",
+  }, {
+    code: `
+      a {
+        width: 10px;             // Inline comment, inside a ruleset.
+      }
+    `,
+    message: messages.rejected,
+    description: "Inline comment, inside a ruleset.",
+  }, {
+    code: `
+      a, // Inline comment, between selectors.
+      b {
+        width: 10px;
+      }
+    `,
+    message: messages.rejected,
+    description: "Inline comment, between selectors.",
+    line: 2,
+    column: 10,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "never", { ignore: ["stylelint-commands"] } ],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: [{
+    code: `
+      a {
+        color: pink; // stylelint-disable something 
+        top: 0;
+      }
+    `,
+    description: "stylelint command inline comment.",
+  }],
+})

--- a/src/rules/double-slash-comment-inline/index.js
+++ b/src/rules/double-slash-comment-inline/index.js
@@ -1,0 +1,67 @@
+import {
+  findCommentsInRaws,
+  namespace,  
+  optionsHaveIgnored,
+} from "../../utils"
+import { utils } from "stylelint"
+
+export const ruleName = namespace("double-slash-comment-inline")
+
+export const messages = utils.ruleMessages(ruleName, {
+  expected: "Expected //-comment to be inline comment",
+  rejected: "Unexpected inline //-comment",
+})
+
+const stylelintCommandPrefix = "stylelint-"
+
+export default function (expectation, options) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: [
+        "always",
+        "never",
+      ],
+    }, {
+      actual: options,
+      possible: {
+        ignore: [
+          "stylelint-commands",
+        ],
+      },
+      optional: true,
+    })
+    if (!validOptions) { return }
+
+    const comments = findCommentsInRaws(root.source.input.css)
+    comments.forEach(comment => {
+      // Only process // comments
+      if (comment.type !== "double-slash") { return }
+      
+      // Optionally ignore stylelint commands
+      if (
+        comment.text.indexOf(stylelintCommandPrefix) === 0
+        && optionsHaveIgnored(options, "stylelint-commands")
+      ) { return }
+      
+      const isInline = comment.inlineAfter || comment.inlineBefore
+      let message
+
+      if (isInline && expectation === "never") {
+        message = messages.rejected
+      } else if (!isInline && expectation === "always") {
+        message = messages.expected
+      } else {
+        return
+      }
+
+      utils.report({
+        message,
+        node: root,
+        index: comment.start,
+        result,
+        ruleName,
+      })
+    })
+  }
+}

--- a/src/rules/double-slash-comment-whitespace-inside/README.md
+++ b/src/rules/double-slash-comment-whitespace-inside/README.md
@@ -1,0 +1,60 @@
+# double-slash-comment-whitespace-inside
+
+Require or disallow whitespace after the `//` in `//`-comments
+
+```scss
+a {
+  width: 10px; // inline-comment
+/*               ↑
+ * Such whitespace */
+```
+
+This rule only works with SCSS-like [single-line comments](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#comments) and ignores CSS comments (`/* */`).
+
+Any number of slases are allowed at the beginning of the comment. So `/// comment` is treated the same way as `// comment`.
+
+Note that a newlint is not possible as a whitespace in terms of this rule as `//`-comments are intended to be single-line.
+
+## Options
+
+`string`: `"always"|"never"`
+
+### `"always"`
+
+There *must always* be whitespace after the `//` inside `//`-comments.
+
+The following patterns are considered warnings:
+
+```scss
+//comment
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+// comment
+```
+
+```scss
+///   comment
+```
+
+### `"never"`
+
+There *must never* be whitespace after the `//` inside `//`-comments.
+
+The following patterns are considered warnings:
+
+```scss
+// comment
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+//comment
+```
+
+```scss
+///comment
+```

--- a/src/rules/double-slash-comment-whitespace-inside/README.md
+++ b/src/rules/double-slash-comment-whitespace-inside/README.md
@@ -13,7 +13,7 @@ This rule only works with SCSS-like [single-line comments](http://sass-lang.com/
 
 Any number of slases are allowed at the beginning of the comment. So `/// comment` is treated the same way as `// comment`.
 
-Note that a newlint is not possible as a whitespace in terms of this rule as `//`-comments are intended to be single-line.
+Note that a newline is not possible as a whitespace in terms of this rule as `//`-comments are intended to be single-line.
 
 ## Options
 

--- a/src/rules/double-slash-comment-whitespace-inside/__tests__/index.js
+++ b/src/rules/double-slash-comment-whitespace-inside/__tests__/index.js
@@ -1,0 +1,83 @@
+import testRule from "stylelint-test-rule-tape"
+import rule, { ruleName, messages } from ".."
+
+// -------------------------------------------------------------------------
+// "always"
+// -------------------------------------------------------------------------
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "// Comment with one space",
+    description: "// Comment with one space.",
+  }, {
+    code: "//    Comment with multiple spaces",
+    description: "//    Comment with multiple spaces.",
+  }, {
+    code: "/// 3-slash comment with space",
+    description: "/// 3-slash comment with space.",
+  }, {
+    code: "/*CSS comment*/",
+    description: "/*CSS comment*/ (ignored)",
+  } ],
+
+  reject: [ {
+    code: "//Comment with no whitespace",
+    description: "//Comment with no whitespace",
+    message: messages.expected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "///3-slash comment with no whitespace",
+    description: "///3-slash comment with no whitespace",
+    message: messages.expected,
+    line: 1,
+    column: 1,
+  } ],
+})
+
+// -------------------------------------------------------------------------
+// "never"
+// -------------------------------------------------------------------------
+
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "//Comment with no whitespace",
+    description: "//Comment with no whitespace",
+  }, {
+    code: "///3-slash comment with no whitespace",
+    description: "///3-slash comment with no whitespace",
+  }, {
+    code: "/*   CSS comment  */",
+    description: "/*   CSS comment  */ (ignored)",
+  } ],
+
+  reject: [ {
+    code: "// Comment with one space",
+    description: "// Comment with one space.",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "//    Comment with multiple spaces",
+    description: "//    Comment with multiple spaces.",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "/// 3-slash comment with space",
+    description: "/// 3-slash comment with space.",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  } ],
+})

--- a/src/rules/double-slash-comment-whitespace-inside/index.js
+++ b/src/rules/double-slash-comment-whitespace-inside/index.js
@@ -1,0 +1,49 @@
+import {
+  findCommentsInRaws,
+  namespace,
+} from "../../utils"
+import { utils } from "stylelint"
+
+export const ruleName = namespace("double-slash-comment-whitespace-inside")
+
+export const messages = utils.ruleMessages(ruleName, {
+  expected: "Expected a space after //",
+  rejected: "Unexpected space after //",
+})
+
+export default function (expectation) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: [
+        "always",
+        "never",
+      ],
+    })
+    if (!validOptions) { return }
+
+    const comments = findCommentsInRaws(root.source.input.css)
+    comments.forEach(comment => {
+      // Only process // comments
+      if (comment.type !== "double-slash") { return }
+
+      let message
+
+      if (comment.raws.left !== "" && expectation === "never") {
+        message = messages.rejected
+      } else if (comment.raws.left === "" && expectation === "always") {
+        message = messages.expected
+      } else {
+        return
+      }
+
+      utils.report({
+        message,
+        node: root,
+        index: comment.start,
+        result,
+        ruleName,
+      })
+    })
+  }
+}

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -9,6 +9,7 @@ import atMixinNoArgumentlessCallParentheses from "./at-mixin-no-argumentless-cal
 import atMixinPattern from "./at-mixin-pattern"
 import dollarVariableNoMissingInterpolation from "./dollar-variable-no-missing-interpolation"
 import dollarVariablePattern from "./dollar-variable-pattern"
+import doubleSlashCommentEmptyLineBefore from "./double-slash-comment-empty-line-before"
 import mediaFeatureValueDollarVariable from "./media-feature-value-dollar-variable"
 import partialNoImport from "./partial-no-import"
 import percentPlaceholderPattern from "./percent-placeholder-pattern"
@@ -26,6 +27,7 @@ export default {
   "at-mixin-pattern": atMixinPattern,
   "dollar-variable-no-missing-interpolation": dollarVariableNoMissingInterpolation,
   "dollar-variable-pattern": dollarVariablePattern,
+  "double-slash-comment-empty-line-before": doubleSlashCommentEmptyLineBefore,
   "media-feature-value-dollar-variable": mediaFeatureValueDollarVariable,
   "percent-placeholder-pattern": percentPlaceholderPattern,
   "partial-no-import": partialNoImport,

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -10,6 +10,7 @@ import atMixinPattern from "./at-mixin-pattern"
 import dollarVariableNoMissingInterpolation from "./dollar-variable-no-missing-interpolation"
 import dollarVariablePattern from "./dollar-variable-pattern"
 import doubleSlashCommentEmptyLineBefore from "./double-slash-comment-empty-line-before"
+import doubleSlashCommentInline from "./double-slash-comment-inline"
 import mediaFeatureValueDollarVariable from "./media-feature-value-dollar-variable"
 import partialNoImport from "./partial-no-import"
 import percentPlaceholderPattern from "./percent-placeholder-pattern"
@@ -28,6 +29,7 @@ export default {
   "dollar-variable-no-missing-interpolation": dollarVariableNoMissingInterpolation,
   "dollar-variable-pattern": dollarVariablePattern,
   "double-slash-comment-empty-line-before": doubleSlashCommentEmptyLineBefore,
+  "double-slash-comment-inline": doubleSlashCommentInline,
   "media-feature-value-dollar-variable": mediaFeatureValueDollarVariable,
   "percent-placeholder-pattern": percentPlaceholderPattern,
   "partial-no-import": partialNoImport,

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -11,6 +11,7 @@ import dollarVariableNoMissingInterpolation from "./dollar-variable-no-missing-i
 import dollarVariablePattern from "./dollar-variable-pattern"
 import doubleSlashCommentEmptyLineBefore from "./double-slash-comment-empty-line-before"
 import doubleSlashCommentInline from "./double-slash-comment-inline"
+import doubleSlashCommentWhitespaceInside from "./double-slash-comment-whitespace-inside"
 import mediaFeatureValueDollarVariable from "./media-feature-value-dollar-variable"
 import partialNoImport from "./partial-no-import"
 import percentPlaceholderPattern from "./percent-placeholder-pattern"
@@ -30,6 +31,7 @@ export default {
   "dollar-variable-pattern": dollarVariablePattern,
   "double-slash-comment-empty-line-before": doubleSlashCommentEmptyLineBefore,
   "double-slash-comment-inline": doubleSlashCommentInline,
+  "double-slash-comment-whitespace-inside": doubleSlashCommentWhitespaceInside,
   "media-feature-value-dollar-variable": mediaFeatureValueDollarVariable,
   "percent-placeholder-pattern": percentPlaceholderPattern,
   "partial-no-import": partialNoImport,

--- a/src/utils/__tests__/findCommentsInRaws.js
+++ b/src/utils/__tests__/findCommentsInRaws.js
@@ -1,0 +1,90 @@
+import { findCommentsInRaws } from "../"
+import postcss from "postcss"
+import scss from "postcss-scss"
+import test from "tape"
+
+function logError(err) {
+  console.log(err.stack) // eslint-disable-line no-console
+}
+
+test("Various.", t => {
+  t.plan(11)
+
+  postcss()
+    .process(`
+      /**! comment */
+      a
+      {}
+      
+      b // comment 2 
+      {
+        width: /* comment 3 */ 100px;
+        background: url(http://lol);
+      }
+    `, { syntax: scss })
+    .then(result => {
+      const css = result.root.source.input.css
+      const comments = findCommentsInRaws(css)
+      
+      t.equal(comments.length, 3)
+      t.equal(comments[0].text, "comment")
+      t.equal(comments[0].inlineAfter, false)
+      t.equal(comments[1].type, "double-slash")
+      t.equal(comments[1].text, "comment 2")
+      t.equal(comments[1].start, 55)
+      t.equal(comments[1].end, 67)
+      t.equal(comments[1].inlineAfter, true)
+      t.equal(comments[2].inlineBefore, true)
+      t.equal(comments[2].inlineAfter, true)
+      t.equal(comments[2].start, 92)
+    })
+    .catch(logError)
+})
+
+test("", t => {
+  t.plan(2)
+
+  postcss()
+    .process(`
+      a { // Inline comment, after {.
+        width: 10px;
+      }
+    `, { syntax: scss })
+    .then(result => {
+      const css = result.root.source.input.css
+      const comments = findCommentsInRaws(css)
+      
+      t.equal(comments.length, 1)
+      t.equal(comments[0].inlineAfter, true)
+    })
+    .catch(logError)
+})
+
+test("", t => {
+  t.plan(2)
+
+  postcss()
+    .process("a {} // comment", { syntax: scss })
+    .then(result => {
+      const css = result.root.source.input.css
+      const comments = findCommentsInRaws(css)
+      t.equal(comments.length, 1)
+      t.equal(comments[0].inlineAfter, true)
+    })
+    .catch(logError)
+})
+
+test("Triple-slash comment", t => {
+  t.plan(3)
+
+  postcss()
+    .process("a {} /// comment", { syntax: scss })
+    .then(result => {
+      const css = result.root.source.input.css
+      const comments = findCommentsInRaws(css)
+      t.equal(comments.length, 1)
+      t.equal(comments[0].inlineAfter, true)
+      t.equal(comments[0].raws.left, " ")
+    })
+    .catch(logError)
+})

--- a/src/utils/__tests__/isInlineComment.js
+++ b/src/utils/__tests__/isInlineComment.js
@@ -15,11 +15,9 @@ test("Single-line comment, after ruleset.", t => {
       a {} // comment
     `, { syntax: scss })
     .then(result => {
-      let res = null
       result.root.walkComments(comment => {
-        res = isInlineComment(comment)
+        t.equal(isInlineComment(comment), true)
       })
-      t.equal(res, true)
     })
     .catch(logError)
 })
@@ -32,11 +30,9 @@ test("CSS comment, after ruleset.", t => {
       a {} /* comment */
     `, { syntax: scss })
     .then(result => {
-      let res = null
       result.root.walkComments(comment => {
-        res = isInlineComment(comment)
+        t.equal(isInlineComment(comment), true)
       })
-      t.equal(res, true)
     })
     .catch(logError)
 })
@@ -51,11 +47,9 @@ test("Single-line comment, after a decl.", t => {
       }
     `, { syntax: scss })
     .then(result => {
-      let res = null
       result.root.walkComments(comment => {
-        res = isInlineComment(comment)
+        t.equal(isInlineComment(comment), true)
       })
-      t.equal(res, true)
     })
     .catch(logError)
 })
@@ -70,11 +64,9 @@ test("CSS comment, before a decl.", t => {
       }
     `, { syntax: scss })
     .then(result => {
-      let res = null
       result.root.walkComments(comment => {
-        res = isInlineComment(comment)
+        t.equal(isInlineComment(comment), true)
       })
-      t.equal(res, true)
     })
     .catch(logError)
 })
@@ -89,11 +81,9 @@ test("Inline comment, after a {.", t => {
       }
     `, { syntax: scss })
     .then(result => {
-      let res = null
       result.root.walkComments(comment => {
-        res = isInlineComment(comment)
+        t.equal(isInlineComment(comment), true)
       })
-      t.equal(res, true)
     })
     .catch(logError)
 })
@@ -147,11 +137,9 @@ test("Multi-line comment, after a ruleset (new line).", t => {
       /* comment */
     `, { syntax: scss })
     .then(result => {
-      let res = null
       result.root.walkComments(comment => {
-        res = isInlineComment(comment)
+        t.equal(isInlineComment(comment), false)
       })
-      t.equal(res, false)
     })
     .catch(logError)
 })
@@ -165,11 +153,9 @@ test("Single-line comment, after a ruleset (new line).", t => {
       // comment
     `, { syntax: scss })
     .then(result => {
-      let res = null
       result.root.walkComments(comment => {
-        res = isInlineComment(comment)
+        t.equal(isInlineComment(comment), false)
       })
-      t.equal(res, false)
     })
     .catch(logError)
 })

--- a/src/utils/__tests__/isInlineComment.js
+++ b/src/utils/__tests__/isInlineComment.js
@@ -1,0 +1,175 @@
+import { isInlineComment } from "../"
+import postcss from "postcss"
+import scss from "postcss-scss"
+import test from "tape"
+
+function logError(err) {
+  console.log(err.stack) // eslint-disable-line no-console
+}
+
+test("Single-line comment, after ruleset.", t => {
+  t.plan(1)
+
+  postcss()
+    .process(`
+      a {} // comment
+    `, { syntax: scss })
+    .then(result => {
+      let res = null
+      result.root.walkComments(comment => {
+        res = isInlineComment(comment)
+      })
+      t.equal(res, true)
+    })
+    .catch(logError)
+})
+
+test("CSS comment, after ruleset.", t => {
+  t.plan(1)
+
+  postcss()
+    .process(`
+      a {} /* comment */
+    `, { syntax: scss })
+    .then(result => {
+      let res = null
+      result.root.walkComments(comment => {
+        res = isInlineComment(comment)
+      })
+      t.equal(res, true)
+    })
+    .catch(logError)
+})
+
+test("Single-line comment, after a decl.", t => {
+  t.plan(1)
+
+  postcss()
+    .process(`
+      a {
+        width: 10px; // hmm
+      }
+    `, { syntax: scss })
+    .then(result => {
+      let res = null
+      result.root.walkComments(comment => {
+        res = isInlineComment(comment)
+      })
+      t.equal(res, true)
+    })
+    .catch(logError)
+})
+
+test("CSS comment, before a decl.", t => {
+  t.plan(1)
+
+  postcss()
+    .process(`
+      a {
+        /* CSS comment, before a decl */ width: 10px;
+      }
+    `, { syntax: scss })
+    .then(result => {
+      let res = null
+      result.root.walkComments(comment => {
+        res = isInlineComment(comment)
+      })
+      t.equal(res, true)
+    })
+    .catch(logError)
+})
+
+test("Inline comment, after a {.", t => {
+  t.plan(1)
+
+  postcss()
+    .process(`
+      a { // Inline comment, after a {.
+        width: 10px;
+      }
+    `, { syntax: scss })
+    .then(result => {
+      let res = null
+      result.root.walkComments(comment => {
+        res = isInlineComment(comment)
+      })
+      t.equal(res, true)
+    })
+    .catch(logError)
+})
+
+test("Inline comment, after a selector (in a list). IGNORED.", t => {
+  t.plan(1)
+
+  postcss()
+    .process(`
+      a, // comment
+      b {
+        width: 10px;
+      }
+    `, { syntax: scss })
+    .then(result => {      
+      let res = null
+      result.root.walkComments(comment => {
+        res = isInlineComment(comment)
+      })
+      t.equal(res, null)
+    })
+    .catch(logError)
+})
+
+test("Inline comment, after a selector, comment prior. IGNORED.", t => {
+  t.plan(1)
+
+  postcss()
+    .process(`
+      a,
+      b {
+        width: /* comment inside decl */ 10px;
+      }
+    `, { syntax: scss })
+    .then(result => {
+      let res = null
+      result.root.walkComments(comment => {
+        res = isInlineComment(comment)
+      })
+      t.equal(res, null)
+    })
+    .catch(logError)
+})
+
+test("Multi-line comment, after a ruleset (new line).", t => {
+  t.plan(1)
+
+  postcss()
+    .process(`
+      a {}
+      /* comment */
+    `, { syntax: scss })
+    .then(result => {
+      let res = null
+      result.root.walkComments(comment => {
+        res = isInlineComment(comment)
+      })
+      t.equal(res, false)
+    })
+    .catch(logError)
+})
+
+test("Single-line comment, after a ruleset (new line).", t => {
+  t.plan(1)
+
+  postcss()
+    .process(`
+      a {}
+      // comment
+    `, { syntax: scss })
+    .then(result => {
+      let res = null
+      result.root.walkComments(comment => {
+        res = isInlineComment(comment)
+      })
+      t.equal(res, false)
+    })
+    .catch(logError)
+})

--- a/src/utils/findCommentsInRaws.js
+++ b/src/utils/findCommentsInRaws.js
@@ -1,0 +1,165 @@
+/**
+ * Finds comments, both CSS comments and double slash ones, in a CSS string
+ * This helper exists because PostCSS drops some inline comments (those
+ * between seelctors, property values, etc.)
+ * https://github.com/postcss/postcss/issues/845#issuecomment-232306259
+ *
+ * @param [string] rawString -- the source raw CSS string
+ * @return [array] array of objects with these props:
+ *    • type -- "css" or "double-slash"
+ *    • start -- 0-base index of the comment srart in the source string
+ *    • end -- 0-base index of the comment end in the source string
+ *    • raws
+ *      raws.left -- whitespace after the comment opening marker
+ *      raws.text -- the full comment, including markers (//, /*)
+ *      raws.right -- whitespace before the comment closing marker
+ *    • text -- the comment text only, excluding //, /*, trailing whitespaces
+ *    • inlineAfter -- true, if there is something before the comment on
+ *      the same line
+ *    • inlineBefore -- true, if there is something after the comment on
+ *      the same line
+ */
+
+export default function findCommentsInRaws(rawString) {
+  const result = []
+  let comment = {}
+  // Keeps track of which structure the parser is inside (string, comment,
+  // url function, parens). E.g., /* comment */ inside a string doesn't
+  // constitute a comment, so as url(//path)
+  const modesEntered = [{
+    mode: "normal",
+    character: null,
+  }]
+  
+  for (let i = 0; i < rawString.length; i++) {
+    const character = rawString[i]
+    const prevChar = i > 0 ? rawString[i - 1] : null
+    const nextChar = i + 1 < rawString.length ? rawString[i + 1] : null
+
+    const lastModeIndex = modesEntered.length - 1
+    const mode = modesEntered[lastModeIndex].mode
+    
+    switch (character) {
+      // If entering/exiting a string
+      case "\"":
+      case "'": {
+        if (mode === "comment") { break }
+        if (mode === "string" &&
+          modesEntered[lastModeIndex].character === character &&
+          prevChar !== "\\"
+        ) {
+          // Exiting a string
+          modesEntered.pop()
+        } else {
+          // Entering a string
+          modesEntered.push({
+            mode: "string",
+            character,
+          })
+        }
+        break
+      }
+      // Entering url, other function or parens (only url matters)
+      case "(": {
+        if (mode === "comment" || mode === "string") { break }
+        const functionName =
+          /(?:^|(?:\n)|(?:\r)|(?:\s-)|[\s,.(){}*+/%])([a-zA-Z0-9_-]*)$/
+            .exec(rawString.substring(0, i))[1]
+        modesEntered.push({
+          mode: functionName === "url" ? "url" : "parens",
+          character: "(",
+        })
+        break
+      }
+      // Exiting url, other function or parens
+      case ")": {
+        if (mode === "comment" || mode === "string") { break }
+        modesEntered.pop()
+        break
+      }
+      // checking for comment
+      case "/": {
+        // break if the / is inside a comment because we leap over the second
+        // slash in // and in */, so the / is not from a marker
+        if (mode === "comment" || mode === "string") { break }
+        if (nextChar === "*") {
+          modesEntered.push({
+            mode: "comment",
+            character: "/*",
+          })
+          comment = {
+            type: "css",
+            start: i,
+            inlineAfter: rawString.substring(0, i).search(/\n\s*$/) === -1,
+          }
+          // Skip the next loop as the * is already checked
+          i++
+        } else if (nextChar === "/") {
+          // `url(//path/to/file)` has no comment
+          if (mode === "url") { break }
+          modesEntered.push({
+            mode: "comment",
+            character: "//",
+          })
+          comment = {
+            type: "double-slash",
+            start: i,
+            inlineAfter: rawString.substring(0, i).search(/\n\s*$/) === -1,
+          }
+          // Skip the next loop as the second slash in // is already checked
+          i++
+        }
+        break
+      }
+      // Might be a closing */
+      case "*": {
+        if (mode === "comment" && modesEntered[lastModeIndex].character === "/*" && nextChar === "/") {
+          comment.end = i + 1
+
+          const commentRaw = rawString.substring(comment.start, comment.end + 1)
+          const matches = /^\/\*+[!#]{0,1}(\s*)(.*?)(\s*?)\*\/$/.exec(commentRaw)
+
+          modesEntered.pop()
+          comment.raws = {
+            left: matches[1],
+            text: commentRaw,
+            right: matches[3],
+          }
+          comment.text = matches[2]
+          comment.inlineBefore = rawString.substring(i + 2).search(/^\s*?\S+\s*?\n/) !== -1
+          result.push(Object.assign({}, comment))
+          comment = {}
+          // Skip the next loop as the / in */ is already checked
+          i++
+        }
+        break
+      }
+      default: {
+        // //-comments end before newline and if the code string ends
+        if (character === "\n" || i === rawString.length - 1) {
+          if (mode === "comment" && modesEntered[lastModeIndex].character === "//") {
+            comment.end = i - 1
+
+            const commentRaw = rawString.substring(comment.start, comment.end)
+            const matches = /^\/+(\s*)(.*?)(\s*?)$/.exec(commentRaw)
+
+            modesEntered.pop()
+            comment.raws = {
+              left: matches[1],
+              text: commentRaw,
+              right: matches[3],
+            }
+            comment.text = matches[2]
+            comment.inlineBefore = false
+            result.push(Object.assign({}, comment))
+            comment = {}
+          }
+        }
+        break
+      }
+    }
+    
+  }
+
+  return result
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,7 @@
 export { default as hasInterpolatingAmpersand } from "./hasInterpolatingAmpersand"
 export { default as isStandardRule } from "./isStandardRule"
 export { default as isStandardSelector } from "./isStandardSelector"
-export { default as parseSelector } from "./parseSelector"
 export { default as namespace } from "./namespace"
+export { default as parseSelector } from "./parseSelector"
+export { default as optionsHaveException } from "./optionsHaveException"
+export { default as optionsHaveIgnored } from "./optionsHaveIgnored"

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 export { default as hasInterpolatingAmpersand } from "./hasInterpolatingAmpersand"
+export { default as isInlineComment } from "./isInlineComment"
 export { default as isStandardRule } from "./isStandardRule"
 export { default as isStandardSelector } from "./isStandardSelector"
 export { default as namespace } from "./namespace"

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
+export { default as findCommentsInRaws } from "./findCommentsInRaws"
 export { default as hasInterpolatingAmpersand } from "./hasInterpolatingAmpersand"
 export { default as isInlineComment } from "./isInlineComment"
 export { default as isStandardRule } from "./isStandardRule"

--- a/src/utils/isInlineComment.js
+++ b/src/utils/isInlineComment.js
@@ -1,0 +1,17 @@
+/**
+ * Check if a comment is inline one (i.e. on the same line as some non-comment
+ * code). Only works with comments that are not ignored by PostCSS. To work
+ * with those that are ignored use `findCommentInRaws`
+ *
+ * @param {Comment} comment - PostCSS comment node
+ * @return {boolean} true, if the comment is an inline one
+ */
+
+export default function isInlineComment(comment) {
+  const nextNode = comment.next()
+  const isBeforeSomething = !!nextNode && nextNode.type !== "comment" &&
+    comment.source.end.line === nextNode.source.start.line
+  const isAfterSomething = comment.raws.before.search(/\n/) === -1
+
+  return isAfterSomething || isBeforeSomething
+}

--- a/src/utils/optionsHaveException.js
+++ b/src/utils/optionsHaveException.js
@@ -1,0 +1,16 @@
+/**
+ * Check if an options object contains a certain `except` keyword.
+ * It will look for an `except` property whose value should
+ * be an array of keywords.
+ *
+ * @param {object} options
+ * @param {string} exceptionName
+ * @return {boolean}
+ */
+export default function (options, exceptionName) {
+  return (
+    options
+    && options.except
+    && options.except.indexOf(exceptionName) !== -1
+  )
+}

--- a/src/utils/optionsHaveIgnored.js
+++ b/src/utils/optionsHaveIgnored.js
@@ -1,0 +1,16 @@
+/**
+ * Check if an options object contains a certain `ignore` keyword.
+ * It will look for an `ignore` property whose value should
+ * be an array of keywords.
+ *
+ * @param {object} options
+ * @param {string} ignoredName
+ * @return {boolean}
+ */
+export default function (options, ignoredName) {
+  return (
+    options
+    && options.ignore
+    && options.ignore.indexOf(ignoredName) !== -1
+  )
+}


### PR DESCRIPTION
* `double-slash-comment-empty-line-before`
* `double-slash-comment-inline` (to force/forbid placing //-comments on the same line as other code)
* `double-slash-comment-whitespace-inside`

Implements #48 

PostCSS currently [drops some inline comments](https://github.com/postcss/postcss/issues/845#issuecomment-232306259), like in

```css
a, /* comment */ b { ... }
```

so in order to for the second and the third rules to work properly, without ignoring too much, the utility to parse (S)CSS code solely for comments were created.