### PR TITLE
Testing stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stylelint-scss
 
-[![NPM version](https://img.shields.io/npm/v/stylelint-scss.svg)](https://www.npmjs.org/package/stylelint-scss)
+[![NPM version](https://img.shields.io/npm/v/stylelint-scss.svg)](https://www.npmjs.com/package/stylelint-scss)
 [![Build Status](https://travis-ci.org/kristerkari/stylelint-scss.svg?branch=master)](https://travis-ci.org/kristerkari/stylelint-scss)
 [![Build status](https://ci.appveyor.com/api/projects/status/xa12kju6qmvmqs1n/branch/master?svg=true)](https://ci.appveyor.com/project/kristerkari/stylelint-scss/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/kristerkari/stylelint-scss/badge.svg?branch=master)](https://coveralls.io/github/kristerkari/stylelint-scss?branch=master)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "rimraf": "^2.5.2",
     "semver": "^5.1.0",
     "stylelint-test-rule-tape": "^0.2.0",
+    "tap-spec": "^4.1.1",
     "tape": "^4.6.0"
   },
   "engines": {
@@ -78,6 +79,6 @@
     "prepublish": "npm run build",
     "pretest": "npm run lint",
     "release": "npmpub",
-    "test": "nyc tape -r babel-register \"src/**/__tests__/*.js\""
+    "test": "nyc tape -r babel-register \"src/**/__tests__/*.js\" | tap-spec"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "prepublish": "npm run build",
     "pretest": "npm run lint",
     "release": "npmpub",
-    "test": "nyc tape -r babel-register \"src/**/__tests__/*.js\" | tap-spec"
+    "test": "nyc tape -r babel-register \"src/**/__tests__/*.js\" | tap-spec",
+    "test-rule": "node ./scripts/test-rule.js",
+    "test-util": "node ./scripts/test-util.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash": "^4.11.1",
-    "postcss-media-query-parser": "^0.1.0",
+    "postcss-media-query-parser": "^0.2.1",
     "postcss-resolve-nested-selector": "^0.1.1",
     "postcss-selector-parser": "^2.0.0",
     "postcss-value-parser": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "rimraf": "^2.5.2",
     "semver": "^5.1.0",
     "stylelint-test-rule-tape": "^0.2.0",
+    "table": "3.7.9",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "stylelint": "^7.0.3"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.5",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-tape-runner": "^2.0.1",
+    "babel-cli": "^6.14.0",
+    "babel-preset-es2015": "^6.14.0",
+    "babel-register": "^6.14.0",
     "coveralls": "^2.11.14",
     "eslint": "^2.3.0",
     "eslint-config-stylelint": "^1.0.0",
@@ -35,7 +35,7 @@
     "rimraf": "^2.5.2",
     "semver": "^5.1.0",
     "stylelint-test-rule-tape": "^0.2.0",
-    "tape": "^4.5.1"
+    "tape": "^4.6.0"
   },
   "engines": {
     "node": ">=4.2.1"
@@ -78,6 +78,6 @@
     "prepublish": "npm run build",
     "pretest": "npm run lint",
     "release": "npmpub",
-    "test": "nyc babel-tape-runner \"src/**/__tests__/*.js\""
+    "test": "nyc tape -r babel-register \"src/**/__tests__/*.js\""
   }
 }

--- a/scripts/test-rule.js
+++ b/scripts/test-rule.js
@@ -1,0 +1,17 @@
+// A helper script for testing rules
+// So that we could just run "npm run test-rule partial-no-import"
+
+const exec = require("child_process").exec
+
+process.argv.slice(2).forEach(function (arg) {
+  const cmd = "\"./node_modules/.bin/tape\" -r babel-register \"src/rules/" + arg + "/__tests__/index.js\" | \"./node_modules/.bin/tap-spec\""
+  const child = exec(
+    cmd,
+    { env: { FORCE_COLOR: "always" } }
+    // We actually don't need this callback now
+    // function (error, stdout, stderr) {}
+  )
+
+  child.stdout.pipe(process.stdout)
+  child.stderr.pipe(process.stderr)
+})

--- a/scripts/test-rule.js
+++ b/scripts/test-rule.js
@@ -2,14 +2,14 @@
 // So that we could just run "npm run test-rule partial-no-import"
 
 const exec = require("child_process").exec
+const env = process.env
+env.FORCE_COLOR = 1
 
 process.argv.slice(2).forEach(function (arg) {
   const cmd = "\"./node_modules/.bin/tape\" -r babel-register \"src/rules/" + arg + "/__tests__/index.js\" | \"./node_modules/.bin/tap-spec\""
   const child = exec(
     cmd,
-    { env: { FORCE_COLOR: "always" } }
-    // We actually don't need this callback now
-    // function (error, stdout, stderr) {}
+    env
   )
 
   child.stdout.pipe(process.stdout)

--- a/scripts/test-util.js
+++ b/scripts/test-util.js
@@ -1,0 +1,17 @@
+// A helper script for testing utils
+// So that we could just run "npm run test-util findCommentsInRaws"
+
+const exec = require("child_process").exec
+
+process.argv.slice(2).forEach(function (arg) {
+  const cmd = "\"./node_modules/.bin/tape\" -r babel-register \"src/utils/__tests__/" + arg + ".js\" | \"./node_modules/.bin/tap-spec\""
+  const child = exec(
+    cmd,
+    { env: { FORCE_COLOR: "always" } }
+    // We actually don't need this callback now
+    // function (error, stdout, stderr) {}
+  )
+
+  child.stdout.pipe(process.stdout)
+  child.stderr.pipe(process.stderr)
+})

--- a/scripts/test-util.js
+++ b/scripts/test-util.js
@@ -2,14 +2,14 @@
 // So that we could just run "npm run test-util findCommentsInRaws"
 
 const exec = require("child_process").exec
+const env = process.env
+env.FORCE_COLOR = 1
 
 process.argv.slice(2).forEach(function (arg) {
   const cmd = "\"./node_modules/.bin/tape\" -r babel-register \"src/utils/__tests__/" + arg + ".js\" | \"./node_modules/.bin/tap-spec\""
   const child = exec(
     cmd,
-    { env: { FORCE_COLOR: "always" } }
-    // We actually don't need this callback now
-    // function (error, stdout, stderr) {}
+    env
   )
 
   child.stdout.pipe(process.stdout)

--- a/src/utils/findCommentsInRaws.js
+++ b/src/utils/findCommentsInRaws.js
@@ -1,3 +1,5 @@
+import _ from "lodash"
+
 /**
  * Finds comments, both CSS comments and double slash ones, in a CSS string
  * This helper exists because PostCSS drops some inline comments (those
@@ -141,7 +143,7 @@ export default function findCommentsInRaws(rawString) {
           }
           comment.text = matches[3]
           comment.inlineBefore = rawString.substring(i + 2).search(/^\s*?\S+\s*?\n/) !== -1
-          result.push(Object.assign({}, comment))
+          result.push(_.assign({}, comment))
           comment = {}
           // Skip the next loop as the / in */ is already checked
           i++
@@ -168,7 +170,7 @@ export default function findCommentsInRaws(rawString) {
             }
             comment.text = matches[3]
             comment.inlineBefore = false
-            result.push(Object.assign({}, comment))
+            result.push(_.assign({}, comment))
             comment = {}
             // Compensate for the `*/` added by postcss-scss
             offset += 2


### PR DESCRIPTION
* Replace `babel-tape-runner` with the original `tape`.
    `babel-tape-runner` uses `babel-polyfill`. So if a code has constructs like `Object.assign` which a JS interpreter (e.g. Node v0.12) doesn't, tests will run flawlessly, but actual code runs will throw.
    
    `tape` can "require" external modules befor running tests now, so it's safer to use `tabe -r babel-register`. And I also love ditching big complex stuff for small vanilla stuff :)
    
    The original issue: https://github.com/wavded/babel-tape-runner/issues/15 Thanks @olegskl for investigating.
* Update such Node v0.12 non-compatible code.
* Add [`tap-spec`](https://github.com/scottcorgan/tap-spec) for prettifying the output.
* Add helper scripts for easier test running
    E.g. `npm run test-rule operator-no-unspaced` will run
    
    ```
    node_modules/.bin/tape -r babel-register src/rules/partial-no-import/__tests__/indes.js | node_modules/.bin/tap-spec
    ```
    
    (so tired of typing this all the time)
* update the link to the project's NPM module in README.