### PR TITLE
If else newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Added: `declaration-nested-properties-no-divided-groups` rule.
 - Added: `ignore: "local"|"global"` to the `dollar-variable-pattern` rule.
 - Added: `dollar-variable-empty-line-before` rule.
+- Added: `at-else-closing-brace-newline-after` rule.
+- Added: `at-else-closing-brace-space-after` rule.
+- Added: `at-if-closing-brace-newline-after` rule.
+- Added: `at-if-closing-brace-space-after` rule.
 
 # 1.3.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added: `at-else-closing-brace-space-after` rule.
 - Added: `at-if-closing-brace-newline-after` rule.
 - Added: `at-if-closing-brace-space-after` rule.
+- Added: `at-else-empty-line-before` rule.
 
 # 1.3.4
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Please refer to [stylelint docs](http://stylelint.io/user-guide/) for the detail
 
 Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.fi/vocabs/css/en) they apply to (just like in [stylelint](http://stylelint.io/user-guide/about-rules/)).
 
+Please also see the [example configs](./docs/examples/) for special cases.
+
 ### `@`-else
 
 - [`at-else-closing-brace-newline-after`](./src/rules/at-else-closing-brace-newline-after/README.md): Require or disallow a newline after the closing brace of `@else` statements.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Please also see the [example configs](./docs/examples/) for special cases.
 
 - [`at-else-closing-brace-newline-after`](./src/rules/at-else-closing-brace-newline-after/README.md): Require or disallow a newline after the closing brace of `@else` statements.
 - [`at-else-closing-brace-space-after`](./src/rules/at-else-closing-brace-space-after/README.md): Require a single space or disallow whitespace after the closing brace of `@else` statements.
+- [`at-else-empty-line-before`](./src/rules/at-else-empty-line-before/README.md): Require an empty line or disallow empty lines before `@`-else.
 
 ### `@`-extend
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Please refer to [stylelint docs](http://stylelint.io/user-guide/) for the detail
 
 Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.fi/vocabs/css/en) they apply to (just like in [stylelint](http://stylelint.io/user-guide/about-rules/)).
 
+### `@`-else
+
+- [`at-else-closing-brace-newline-after`](./src/rules/at-else-closing-brace-newline-after/README.md): Require or disallow a newline after the closing brace of `@else` statements.
+- [`at-else-closing-brace-space-after`](./src/rules/at-else-closing-brace-space-after/README.md): Require a single space or disallow whitespace after the closing brace of `@else` statements.
+
 ### `@`-extend
 
 - [`at-extend-no-missing-placeholder`](./src/rules/at-extend-no-missing-placeholder/README.md): Disallow at-extends (`@extend`) with missing placeholders.
@@ -56,6 +61,11 @@ Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.
 ### `@`-function
 
 - [`at-function-pattern`](./src/rules/at-function-pattern/README.md): Specify a pattern for Sass/SCSS-like function names.
+
+### `@`-if
+
+- [`at-if-closing-brace-newline-after`](./src/rules/at-if-closing-brace-newline-after/README.md): Require or disallow a newline after the closing brace of `@if` statements.
+- [`at-if-closing-brace-space-after`](./src/rules/at-if-closing-brace-space-after/README.md): Require a single space or disallow whitespace after the closing brace of `@if` statements.
 
 ### `@`-import
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,5 @@
+# Example configs
+
+This dir contains examples of `.stylelintrc` configuration file for several use cases.
+
+* [Rules for `@if`/`@else` statements](./if-else.md)

--- a/docs/examples/if-else.md
+++ b/docs/examples/if-else.md
@@ -28,6 +28,7 @@ A stylesheet author might want to treat `@if` and `@else` in a special manner, f
 
     "scss/at-else-closing-brace-newline-after": "always-last-in-chain",
     "scss/at-else-closing-brace-space-after": "always-intermediate",
+    "scss/at-else-closing-brace-space-after": "always-intermediate",
     "scss/at-if-closing-brace-newline-after": "always-last-in-chain",
     "scss/at-if-closing-brace-space-after": "always-intermediate"
   }
@@ -120,12 +121,13 @@ These patterns are considered **non-valid**:
     ],
     "at-rule-name-space-after": "always",
     "block-opening-brace-space-before": "always",
-    "block-closing-brace-newline-after": "always"
+    "block-closing-brace-newline-after": "always",
+    "at-else-empty-line-before": "never"
   }
 }
 ```
 
-This code is considered **valid**
+This code is considered **valid**:
 ```scss
 @if {
   // ...
@@ -133,7 +135,10 @@ This code is considered **valid**
 @else {
   // ...
 }
+```
 
+This code is considered **non-valid**:
+```scss
 @if {
   // ...
 }

--- a/docs/examples/if-else.md
+++ b/docs/examples/if-else.md
@@ -1,0 +1,144 @@
+# `@if`/`@else`
+
+A stylesheet author might want to treat `@if` and `@else` in a special manner, for example `@else` should be on the same line as its `@if`'s closing brace while all the other blocks and at-rules has to have newline after their closing brace. stylelint-scss has some rules for this, but from the core stylelint's point of view, `@if` and `@else` SCSS statements are pretty much regular at-rules, so they comply to corresponding `at-rule-...` and `block-...` rules. Below are some configurations that might help you achieve the needed patterns.
+
+---
+
+**Config 1**: `@else` is on the same line as the preceding `@if`/`@else`'s `}`, space between them. Empty line before all at-rules (except `@else`), space before `{`, newline after all `}` except `@if`'s and `@else`'s. 
+
+```json
+{
+  "plugins": [
+    "stylelint-scss"
+  ],
+  "rules": {
+    "at-rule-empty-line-before": [
+      "always", {
+        "ignoreAtRules": [ "else" ]
+      }
+    ],
+    "block-opening-brace-space-before": "always",
+    "block-closing-brace-newline-after": [
+      "always", {
+        "ignoreAtRules": [ "if", "else" ]
+      }
+    ],
+      "at-rule-name-space-after": "always",
+      "rule-non-nested-empty-line-before": "always",
+
+    "scss/at-else-closing-brace-newline-after": "always-last-in-chain",
+    "scss/at-else-closing-brace-space-after": "always-intermediate",
+    "scss/at-if-closing-brace-newline-after": "always-last-in-chain",
+    "scss/at-if-closing-brace-space-after": "always-intermediate"
+  }
+}
+```
+
+This code is considered **valid**
+```scss
+@if {
+  // ...
+}
+
+a {}
+
+@if {
+  // ...
+} @else {
+  // ...
+}
+
+a {}
+
+@if {
+  // ...
+} @else if {
+  // ...
+} @else {
+  // ...
+}
+
+@if {
+  // ...
+} @else
+if {
+  // ...
+} @else {
+  // ...
+}
+
+a {}
+```
+
+These patterns are considered **non-valid**:
+
+```scss
+@if {
+  // ...
+} a {}
+```
+```scss
+@if {
+  // ...
+}@else {
+  // ...
+}
+```
+```scss
+@if {
+  // ...
+} @else if{
+  // ...
+} @else {
+  // ...
+}
+```
+```scss
+@if {
+  // ...
+} @else if{
+  // ...
+} @else {
+  // ...
+}
+```
+
+---
+
+**Config 2**: `@else` is on a newline, no empty line before it. 
+
+```json
+{
+  "plugins": [
+    "stylelint-scss"
+  ],
+  "rules": {
+    "at-rule-empty-line-before": [
+      "always", {
+        "ignoreAtRules": [ "else" ]
+      }
+    ],
+    "at-rule-name-space-after": "always",
+    "block-opening-brace-space-before": "always",
+    "block-closing-brace-newline-after": "always"
+  }
+}
+```
+
+This code is considered **valid**
+```scss
+@if {
+  // ...
+}
+@else {
+  // ...
+}
+
+@if {
+  // ...
+}
+
+@else {
+  // ...
+}
+```

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
   },
   "files": [
     "dist",
+    "docs",
+    "src/**/README.md",
     "!**/__tests__"
   ],
   "homepage": "https://github.com/kristerkari/stylelint-scss#readme",

--- a/src/rules/at-else-closing-brace-newline-after/README.md
+++ b/src/rules/at-else-closing-brace-newline-after/README.md
@@ -1,0 +1,66 @@
+# at-else-closing-brace-newline-after
+
+Require or disallow a newline after the closing brace of `@else` statements.
+
+```scss
+@if (@a == 0) {
+
+} @else if (@a == 1){ }
+@else { }             ↑
+/**     ↑             ↑
+ * The newline after these braces */
+```
+
+This rule might have conflicts with stylelint's core rule [`block-closing-brace-newline-after`](http://stylelint.io/user-guide/rules/block-closing-brace-newline-after/) if it doesn't have `"ignoreAtRules": ["else"]` in a `.stylelintrc` config file.  That's because an `@else { ... }` statement can be successfully parsed as an at-rule with a block. You might also want to set `"ignoreAtRules": ["else"]` for another stylelint's core rule - [`at-rule-empty-line-before`](http://stylelint.io/user-guide/rules/at-rule-empty-line-before/) that could be forcing empty lines before at-rules (including `@else`s that follow `@if`s or other `@else`s).
+
+This rule doesn't have usual `"always"` and `"never"` main option values, because if you don't need special behavior for `@if` and `@else` you could just use [`block-closing-brace-newline-after`](http://stylelint.io/user-guide/rules/block-closing-brace-newline-after/) set to `"always"` or any other value.
+
+## Options
+
+`string`: `"always-last-in-chain"`
+
+### `"always-last-in-chain"`
+
+There *must always* be a newline after the closing brace of `@else` that is the last statement in a conditional statement chain (i.e. has no `@else` right after it). If it's not, there *must not* be a newline.
+
+The following patterns are considered warnings:
+
+```scss
+a {
+  @if ($x == 1) {
+    // ...
+  } @else {
+    // ...
+  } width: 10px; // No @else after, so should have a newline
+}
+
+@if ($x == 1) {
+  // ...
+} @else if { } // Has @else after it, so shouldn't have a newline
+@else { }
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+a {
+  @if ($x == 1) {} @else {}
+  width: 10px;
+}
+
+a {
+  @if ($x == 1) {
+    // ...
+  } @else if {
+    // ...
+  } @else {}
+
+  width: 10px;
+}
+
+a {
+  @if ($x == 1) { } @else if { }@else { }
+
+  width: 10px;
+}
+```

--- a/src/rules/at-else-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/at-else-closing-brace-newline-after/__tests__/index.js
@@ -1,0 +1,94 @@
+import rule, { ruleName, messages } from ".."
+import testRule from "stylelint-test-rule-tape"
+
+testRule(rule, {
+  ruleName,
+  config: ["always-last-in-chain"],
+  syntax: "scss",
+
+  accept: [ {
+    code: `a {
+      @if ($x == 1) {} @else {}
+      width: 10px;
+    }`,
+    description: "always-last-in-chain (no following @else, has newline after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {} @else {}
+
+      width: 10px;
+    }`,
+    description: "always-last-in-chain (no following @else, has blank line after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      } @else if {
+        
+      } @else {}
+
+      width: 10px;
+    }`,
+    description: "always-last-in-chain (has following @else, this one with no newline after, the following has it).",
+  }, {
+    code: `a {
+      @if ($x == 1) { } @else if { } @else { }
+
+      width: 10px;
+    }`,
+    description: "always-last-in-chain (has following @else, single-line, this one with no newline after, the following has it).",
+  }, {
+    code: `a {
+      @if ($x == 1) { } @else { }
+
+      @include x;
+    }`,
+    description: "always-last-in-chain (followed by non-@else at-rule, single-line, empty line after).",
+  }, {
+    code: "@if ($x == 1) {} @else { }",
+    description: "always-last-in-chain (single line, nothing after).",
+  } ],
+
+  reject: [ {
+    code: `a {
+      @if ($x == 1) {
+        
+      } @else {
+        
+      } width: 10px;
+    }`,
+    description: "always-last-in-chain (has decl on the same line as its closing brace).",
+    message: messages.expected,
+    line: 6,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      } @else if { }
+      @else { }
+    }`,
+    description: "always-last-in-chain (has following @else, newline after).",
+    message: messages.rejected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      } @else { }
+      
+      @else { }
+    }`,
+    description: "always-last-in-chain (has following @else, empty line after).",
+    message: messages.rejected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      } @else {} @include x;
+    }`,
+    description: "always-last-in-chain (followed by non-@else at-rule, no newline after).",
+    message: messages.expected,
+    line: 4,
+  } ],
+})

--- a/src/rules/at-else-closing-brace-newline-after/index.js
+++ b/src/rules/at-else-closing-brace-newline-after/index.js
@@ -1,0 +1,23 @@
+import { namespace } from "../../utils"
+import { utils } from "stylelint"
+
+export const ruleName = namespace("at-else-closing-brace-newline-after")
+
+export const messages = utils.ruleMessages(ruleName, {
+  expected: "Expected newline after \"}\" of @else statement",
+  rejected: "Unexpected newline after \"}\" of @else statement",
+})
+
+import { sassConditionalBraceNLAfterChecker } from "../at-if-closing-brace-newline-after"
+
+export default function (expectation) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: ["always-last-in-chain"],
+    })
+    if (!validOptions) { return }
+
+    sassConditionalBraceNLAfterChecker({ root, result, ruleName, atRuleName: "else", expectation, messages })
+  }
+}

--- a/src/rules/at-else-closing-brace-space-after/README.md
+++ b/src/rules/at-else-closing-brace-space-after/README.md
@@ -1,0 +1,129 @@
+# at-else-closing-brace-space-after
+
+Require a single space or disallow whitespace after the closing brace of `@else` statements.
+
+```scss
+@if ($a == 0) { }
+@else if ($x == 2) { }
+                     ↑
+/**                  ↑
+ * The space after this brace */
+```
+
+This rule might have conflicts with stylelint's core [`block-closing-brace-space-after`](http://stylelint.io/user-guide/rules/block-closing-brace-space-after/) rule if the latter is set up in your `.stylelintrc` config file.
+
+## Options
+
+`string`: `"always-intermediate"|"never-intermediate"`
+
+### `"always-intermediate"`
+
+There *must always* be a single space after the closing brace of `@else` that is not the last statement in a conditional statement chain (i.e. does have another `@else` right after it).
+
+The following patterns are considered warnings:
+
+```scss
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+}@else {}
+
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+}
+@else { }
+
+// `@else if` has a space and a newline after the closing brace
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+} 
+@else { }
+
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+}  @else { } // Two spaces
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+} @else {}
+      
+a {
+  @if ($x == 1) {
+    // ...
+  } @else ($x == 2) {
+    // ...
+  }
+  width: 10px;
+}
+
+@if ($x == 1) { } @else if ($x == 2) { 
+  // ...
+} @include x;
+
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+} @include x;
+```
+
+### `"never-intermediate"`
+
+There *must never* be a whitespace after the closing brace of `@else` that is not the last statement in a conditional statement chain (i.e. does have another `@else` right after it).
+
+The following patterns are considered warnings:
+
+```scss
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+} @else {}
+
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+}
+@else { }
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@if ($x == 1) {
+  // ...
+}@else {}
+
+a {
+  @if ($x == 1) {
+    // ...
+  } @else if ($x == 2) {
+    // ...
+  }
+  width: 10px;
+}
+
+@if ($x == 1) { } @else if ($x == 2) {
+  // ...
+}@include x;
+
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+} @include x;
+```

--- a/src/rules/at-else-closing-brace-space-after/__tests__/index.js
+++ b/src/rules/at-else-closing-brace-space-after/__tests__/index.js
@@ -1,0 +1,193 @@
+import rule, { ruleName, messages } from ".."
+import testRule from "stylelint-test-rule-tape"
+
+// always-intermediate
+testRule(rule, {
+  ruleName,
+  config: ["always-intermediate"],
+  syntax: "scss",
+
+  accept: [ {
+    code: `a {
+      @if ($x == 1) {}
+      width: 10px;
+    }`,
+    description: "always-intermediate (no @else at all).",
+  }, {
+    code: `a {
+      @if ($x == 1) { }
+      @else { }
+      width: 10px;
+    }`,
+    description: "always-intermediate (not an intermediate @else, newline after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {} @else {}width: 10px;
+    }`,
+    description: "always-intermediate (not an intermediate @else, no whitespace after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {} @else if ($x ==2) {
+        
+      } @else {}
+
+      width: 10px;
+    }`,
+    description: "always-intermediate (an intermediate @else, has space after).",
+  }, {
+    code: `a {
+      @if ($x == 1) { } @else if ($x ==2) { } @else { }
+
+      width: 10px;
+    }`,
+    description: "always-intermediate (an intermediate @else, single-line, has space after).",
+  }, {
+    code: `a {
+      @if ($x == 1) { } @else ($x ==2) {}@include x;
+    }`,
+    description: "always-intermediate (@else followed by non-@else at-rule, no space after).",
+  }, {
+    code: "@if ($x == 1) {} @else ($x ==2) {}",
+    description: "always-intermediate (single line, nothing after).",
+  }, {
+    // TODO: should warn on this?
+    code: `a {
+      @if ($x == 1) { } @else ($x ==2) {
+        
+      } @include x;
+    }`,
+    description: "always-intermediate (followed by non-@else at-rule, has space after).",
+  } ],
+
+  reject: [ {
+    code: `a {
+      @if ($x == 1) { } @else ($x ==2) {
+        
+      }@else {}
+    }`,
+    description: "always-intermediate (an intermediate @else, no space after).",
+    message: messages.expected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) { } @else ($x ==2) {
+        
+      }
+      @else { }
+    }`,
+    description: "always-intermediate (an intermediate @else, newline after).",
+    message: messages.expected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) { } @else ($x ==2) {
+        
+      } 
+      @else { }
+    }`,
+    description: "always-intermediate (an intermediate @else, a space and an newline after).",
+    message: messages.expected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) { } @else ($x ==2) {
+        
+      }  @else { }
+    }`,
+    description: "always-intermediate (an intermediate @else, multiple spaces after).",
+    message: messages.expected,
+    line: 4,
+  } ],
+})
+
+// never-intermediate
+testRule(rule, {
+  ruleName,
+  config: ["never-intermediate"],
+  syntax: "scss",
+
+  accept: [ {
+    code: `a {
+      @if ($x == 1) {} @else ($x ==2) {}
+      width: 10px;
+    }`,
+    description: "never-intermediate (not an intermediate @else, has newline after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {} @else ($x ==2) {}width: 10px;
+    }`,
+    description: "never-intermediate (not an intermediate @else, no whitespace after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {} @else ($x ==2) {} width: 10px;
+    }`,
+    description: "never-intermediate (not an intermediate @else, has a space after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {} @else ($x ==2) {
+        
+      }@else {}
+
+      width: 10px;
+    }`,
+    description: "never-intermediate (an intermediate @else, no space after).",
+  }, {
+    code: `a {
+      @if ($x == 1) { }    @else ($x ==2) {}@else { }
+
+      width: 10px;
+    }`,
+    description: "never-intermediate (an intermediate @else, single-line, no space after).",
+  }, {
+    code: "@if ($x == 1) {} @else ($x ==2) {}",
+    description: "never-intermediate (single line, nothing after).",
+  }, {
+    // TODO: should warn on this?
+    code: `a {
+      @if ($x == 1) {
+        
+      } @else ($x ==2) {} @include x;
+    }`,
+    description: "never-intermediate (followed by non-@else at-rule, has space after).",
+  } ],
+
+  reject: [ {
+    code: `a {
+      @if ($x == 1) {} @else ($x ==2) {
+        
+      } @else {}
+    }`,
+    description: "never-intermediate (an intermediate @else, has space after).",
+    message: messages.rejected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {} @else ($x ==2) {
+        
+      }
+      @else { }
+    }`,
+    description: "never-intermediate (an intermediate @else, newline after).",
+    message: messages.rejected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {} @else ($x ==2) {
+        
+      } 
+      @else { }
+    }`,
+    description: "never-intermediate (an intermediate @else, a space and a newline after).",
+    message: messages.rejected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      } @else ($x ==2) {}  @else { }
+    }`,
+    description: "never-intermediate (an intermediate @else, multiple spaces after).",
+    message: messages.rejected,
+    line: 4,
+  } ],
+})

--- a/src/rules/at-else-closing-brace-space-after/index.js
+++ b/src/rules/at-else-closing-brace-space-after/index.js
@@ -1,0 +1,22 @@
+import { namespace } from "../../utils"
+import { utils } from "stylelint"
+import { sassConditionalBraceSpaceAfterChecker } from "../at-if-closing-brace-space-after"
+
+export const ruleName = namespace("at-else-closing-brace-space-after")
+
+export const messages = utils.ruleMessages(ruleName, {
+  expected: "Expected single space after \"}\" of @else statement",
+  rejected: "Unexpected space after \"}\" of @else statement",
+})
+
+export default function (expectation) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: [ "always-intermediate", "never-intermediate" ],
+    })
+    if (!validOptions) { return }
+
+    sassConditionalBraceSpaceAfterChecker({ root, result, ruleName, atRuleName: "else", expectation, messages })
+  }
+}

--- a/src/rules/at-else-empty-line-before/README.md
+++ b/src/rules/at-else-empty-line-before/README.md
@@ -1,0 +1,63 @@
+# at-else-empty-line-before
+
+Require an empty line or disallow empty lines before `@`-else.
+
+```scss
+@if ($a == 0) { }
+                      /* ← */
+@else if ($x == 2) { }   ↑
+                         ↑
+/**                      ↑
+ * This empty line */
+```
+
+`@if` and `@else` statements might need to have different behavior than all the other at-rules. For that you might need to set `"ignoreAtRules": ["else"]` for stylelint's core rule [`at-rule-empty-line-before`](http://stylelint.io/user-guide/rules/at-rule-empty-line-before/). But that would make you unable to disallow empty lines before `@else` while forcing it to be on a new line. This rule is designed to solve exactly that.
+
+## Options
+
+`string`: `"never"`
+
+There is no `"always"`, `"always-single-line"` options, because for such cases stylelint's `at-rule-empty-line-before` would work.
+
+### `"never"`
+
+There *must never* be an empty line before `@else` statements.
+
+The following patterns are considered warnings:
+
+```scss
+@if ($x == 1) {
+  // ...
+}
+
+@else {}
+```
+```scss
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+}
+
+
+@else { }
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@if ($x == 1) {
+  // ...
+} @else if ($x == 2) {
+  // ...
+} @else {}
+      
+a {
+  @if ($x == 1) {
+    // ...
+  }
+  @else ($x == 2) {
+    // ...
+  }
+}
+```

--- a/src/rules/at-else-empty-line-before/__tests__/index.js
+++ b/src/rules/at-else-empty-line-before/__tests__/index.js
@@ -1,0 +1,48 @@
+import rule, { ruleName, messages } from ".."
+import testRule from "stylelint-test-rule-tape"
+
+// always-intermediate
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  syntax: "scss",
+
+  accept: [ {
+    code: `a {
+      @if ($x == 1) {
+        // ...
+      } @else if ($x == 2) {
+        // ...
+      } @else {}
+    }`,
+    description: "never (no newline for @else).",
+  }, {
+    code: `a {
+     @if ($x == 1) {
+        // ...
+      }
+      @else ($x == 2) {
+        // ...
+      }
+    }`,
+    description: "never (no empty line for @else).",
+  } ],
+
+  reject: [ {
+    code: `a {
+      @if ($x == 1) {
+        // ...
+      }
+
+      @else {}
+    }`,
+    description: "never (one empty line before @else)",
+    message: messages.rejected,
+    line: 6,
+  }, {
+    code: "a { @if ($x == 1) { } \n\n @else if ($x == 2) { } \n @else { } }",
+    description: "never (two empty lines before @else if)",
+    message: messages.rejected,
+    line: 3,
+  } ],
+})

--- a/src/rules/at-else-empty-line-before/index.js
+++ b/src/rules/at-else-empty-line-before/index.js
@@ -1,0 +1,38 @@
+import {
+  hasEmptyLine,
+  namespace,
+} from "../../utils"
+import { utils } from "stylelint"
+
+export const ruleName = namespace("at-else-empty-line-before")
+
+export const messages = utils.ruleMessages(ruleName, {
+  rejected: "Unxpected empty line before @else",
+})
+
+export default function (expectation) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: ["never"],
+    })
+    if (!validOptions) { return }
+
+    root.walkAtRules(atrule => {
+
+      if (atrule.name !== "else") { return }
+
+      // Don't need to ignore "the first rule in a stylesheet", etc, cases
+      // because @else should always go after @if
+
+      if (!hasEmptyLine(atrule.raws.before)) { return }
+
+      utils.report({
+        message: messages.rejected,
+        node: atrule,
+        result,
+        ruleName,
+      })
+    })
+  }
+}

--- a/src/rules/at-if-closing-brace-newline-after/README.md
+++ b/src/rules/at-if-closing-brace-newline-after/README.md
@@ -1,0 +1,53 @@
+# at-if-closing-brace-newline-after
+
+Require or disallow a newline after the closing brace of `@if` statements.
+
+```scss
+@if ($a == 0) { }
+                ↑
+/**             ↑
+ * The newline after this brace */
+```
+
+This rule might have conflicts with stylelint's core rule [`block-closing-brace-newline-after`](http://stylelint.io/user-guide/rules/block-closing-brace-newline-after/) if it doesn't have `"ignoreAtRules": ["if"]` in a `.stylelintrc` config file. That's because an `@if { ... }` statement can be successfully parsed as an at-rule with a block. You might also want to set `"ignoreAtRules": ["else"]` for another stylelint's core rule - [`at-rule-empty-line-before`](http://stylelint.io/user-guide/rules/at-rule-empty-line-before/) that could be forcing empty lines before at-rules (including `@else`s that follow `@if`s or other `@else`s).
+
+This rule doesn't have usual `"always"` and `"never"` main option values, because if you don't need special behavior for `@if` and `@else` you could just use [`block-closing-brace-newline-after`](http://stylelint.io/user-guide/rules/block-closing-brace-newline-after/) set to `"always"` or any other value.
+
+## Options
+
+`string`: `"always-last-in-chain"`
+
+### `"always-last-in-chain"`
+
+There *must always* be a newline after the closing brace of `@if` that is the last statement in a conditional statement chain (i.e. has no `@else` right after it). If it's not, there *must not* be a newline.
+
+The following patterns are considered warnings:
+
+```scss
+a {
+  @if ($x == 1) {
+    // ...
+  } width: 10px; // No @else - should have a newline
+}
+
+@if ($x == 1) {
+  // ...
+} // Has @else - shouldn't have a newline
+@else { }
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+a {
+  @if ($x == 1) {}
+  width: 10px;
+}
+
+@if ($x == 1) {
+  // ...
+} @else {} // Has @else, so no newline needed
+
+@if ($x == 1) { }@else { }
+```
+

--- a/src/rules/at-if-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/at-if-closing-brace-newline-after/__tests__/index.js
@@ -1,0 +1,90 @@
+import rule, { ruleName, messages } from ".."
+import testRule from "stylelint-test-rule-tape"
+
+testRule(rule, {
+  ruleName,
+  config: ["always-last-in-chain"],
+  syntax: "scss",
+
+  accept: [ {
+    code: `a {
+      @if ($x == 1) {}
+      width: 10px;
+    }`,
+    description: "always-last-in-chain (no @else, has newline after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {}
+
+      width: 10px;
+    }`,
+    description: "always-last-in-chain (no @else, has blank line after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      } @else {}
+
+      width: 10px;
+    }`,
+    description: "always-last-in-chain (has @else, no newline after).",
+  }, {
+    code: `a {
+      @if ($x == 1) { } @else { }
+
+      width: 10px;
+    }`,
+    description: "always-last-in-chain (has @else, single-line, no newline after).",
+  }, {
+    code: `a {
+      @if ($x == 1) { }
+
+      @include x;
+    }`,
+    description: "always-last-in-chain (followed by non-@else at-rule, single-line, empty line after).",
+  }, {
+    code: "@if ($x == 1) {}",
+    description: "always-last-in-chain (single line, nothing after).",
+  } ],
+
+  reject: [ {
+    code: `a {
+      @if ($x == 1) {
+        
+      } width: 10px;
+    }`,
+    description: "always-last-in-chain (has decl on the same line as its closing brace).",
+    message: messages.expected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      }
+      @else { }
+    }`,
+    description: "always-last-in-chain (has @else, newline after).",
+    message: messages.rejected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      }
+
+      @else { }
+    }`,
+    description: "always-last-in-chain (has @else, empty line after).",
+    message: messages.rejected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      } @include x;
+    }`,
+    description: "always-last-in-chain (followed by non-@else at-rule, no newline after).",
+    message: messages.expected,
+    line: 4,
+  } ],
+})

--- a/src/rules/at-if-closing-brace-newline-after/index.js
+++ b/src/rules/at-if-closing-brace-newline-after/index.js
@@ -1,0 +1,69 @@
+import {
+  isSingleLineString,
+  namespace,
+} from "../../utils"
+import { utils } from "stylelint"
+
+export const ruleName = namespace("at-if-closing-brace-newline-after")
+
+export const messages = utils.ruleMessages(ruleName, {
+  expected: "Expected newline after \"}\" of @if statement",
+  rejected: "Unexpected newline after \"}\" of @if statement",
+})
+
+export default function (expectation) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: ["always-last-in-chain"],
+    })
+    if (!validOptions) { return }
+
+    sassConditionalBraceNLAfterChecker({ root, result, ruleName, atRuleName: "if", expectation, messages })
+  }
+}
+
+/**
+ * The core logic for this rule. Can be imported by other rules with similar
+ * logic, namely at-else-closing-brace-newline-after
+ *
+ * @param {Object} args -- Named arguments object
+ * @param {PostCSS root} args.root
+ * @param {PostCSS result} args.result
+ * @param {String ruleName} args.ruleName - needed for `report` function
+ * @param {String} args.atRuleName - the name of the at-rule to be checked, e.g. "if", "else"
+ * @param {Object} args.messages - returned by stylelint.utils.ruleMessages
+ * @return {undefined} 
+ */
+export function sassConditionalBraceNLAfterChecker({ root, result, ruleName, atRuleName, expectation, messages }) {
+  function complain(node, message, index) {
+    utils.report({
+      result,
+      ruleName,
+      node,
+      message,
+      index,
+    })
+  }
+
+  root.walkAtRules(atrule => {
+    // Do nothing if it's not an @if
+    if (atrule.name !== atRuleName) { return }
+
+    const nextNode = atrule.next()
+    if (!nextNode) { return }
+
+    const nextBefore = nextNode.raws.before
+    const hasNewLinesBeforeNext = nextBefore && !isSingleLineString(nextBefore)
+    const reportIndex = atrule.toString().length
+
+    if (expectation === "always-last-in-chain") {
+      // If followed by @else, no newline is needed
+      if (nextNode.type === "atrule" && nextNode.name === "else") {
+        if (hasNewLinesBeforeNext) { complain(atrule, messages.rejected, reportIndex) }
+      } else {
+        if (!hasNewLinesBeforeNext) { complain (atrule, messages.expected, reportIndex) }
+      }
+    }
+  })
+}

--- a/src/rules/at-if-closing-brace-space-after/README.md
+++ b/src/rules/at-if-closing-brace-space-after/README.md
@@ -1,0 +1,98 @@
+# at-if-closing-brace-space-after
+
+Require a single space or disallow whitespace after the closing brace of `@if` statements.
+
+```scss
+@if ($a == 0) { }
+                ↑
+/**             ↑
+ * The space after this brace */
+```
+
+This rule might have conflicts with stylelint's core [`block-closing-brace-space-after`](http://stylelint.io/user-guide/rules/block-closing-brace-space-after/) rule if the latter is set up in your `.stylelintrc` config file.
+
+## Options
+
+`string`: `"always-intermediate"|"never-intermediate"`
+
+### `"always-intermediate"`
+
+There *must always* be a single space after the closing brace of `@if` that is not the last statement in a conditional statement chain (i.e. does have `@else` right after it).
+
+The following patterns are considered warnings:
+
+```scss
+@if ($x == 1) {
+  // ...
+}@else {}
+
+@if ($x == 1) {
+  // ...
+}
+@else { }
+
+// `@if` has a space and a newline after the closing brace
+@if ($x == 1) {
+  // ...
+} 
+@else { }
+
+@if ($x == 1) {
+  // ...
+}  @else { } // Two spaces
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@if ($x == 1) {
+  // ...
+} @else {}
+
+a {
+  @if ($x == 1) {}
+  width: 10px;
+}
+
+@if ($x == 1) { }@include x;
+
+@if ($x == 1) {
+  // ...
+} @include x;
+```
+
+### `"never-intermediate"`
+
+There *must never* be a whitespace after the closing brace of `@if` that is not the last statement in a conditional statement chain (i.e. does have `@else` right after it).
+
+The following patterns are considered warnings:
+
+```scss
+@if ($x == 1) {
+  // ...
+} @else {}
+
+@if ($x == 1) {
+  // ...
+}
+@else { }
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@if ($x == 1) {
+  // ...
+}@else {}
+      
+a {
+  @if ($x == 1) {}
+  width: 10px;
+}
+
+@if ($x == 1) { }@include x;
+
+@if ($x == 1) {
+  // ...
+} @include x;
+```

--- a/src/rules/at-if-closing-brace-space-after/__tests__/index.js
+++ b/src/rules/at-if-closing-brace-space-after/__tests__/index.js
@@ -1,0 +1,186 @@
+import rule, { ruleName, messages } from ".."
+import testRule from "stylelint-test-rule-tape"
+
+// always-intermediate
+testRule(rule, {
+  ruleName,
+  config: ["always-intermediate"],
+  syntax: "scss",
+
+  accept: [ {
+    code: `a {
+      @if ($x == 1) {}
+      width: 10px;
+    }`,
+    description: "always-intermediate (no @else, has newline after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {}width: 10px;
+    }`,
+    description: "always-intermediate (no @else, no whitespace after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      } @else {}
+
+      width: 10px;
+    }`,
+    description: "always-intermediate (has @else, has space after).",
+  }, {
+    code: `a {
+      @if ($x == 1) { } @else { }
+
+      width: 10px;
+    }`,
+    description: "always-intermediate (has @else, single-line, has space after).",
+  }, {
+    code: `a {
+      @if ($x == 1) { }@include x;
+    }`,
+    description: "always-intermediate (followed by non-@else at-rule, no space after).",
+  }, {
+    code: "@if ($x == 1) {}",
+    description: "always-intermediate (single line, nothing after).",
+  }, {
+    // TODO: should warn on this?
+    code: `a {
+      @if ($x == 1) {
+        
+      } @include x;
+    }`,
+    description: "always-intermediate (followed by non-@else at-rule, has space after).",
+  } ],
+
+  reject: [ {
+    code: `a {
+      @if ($x == 1) {
+        
+      }@else {}
+    }`,
+    description: "always-intermediate (has @else, no space after).",
+    message: messages.expected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      }
+      @else { }
+    }`,
+    description: "always-intermediate (has @else, newline after).",
+    message: messages.expected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      } 
+      @else { }
+    }`,
+    description: "always-intermediate (has @else, a space and an newline after).",
+    message: messages.expected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      }  @else { }
+    }`,
+    description: "always-intermediate (has @else, multiple spaces after).",
+    message: messages.expected,
+    line: 4,
+  } ],
+})
+
+// never-intermediate
+testRule(rule, {
+  ruleName,
+  config: ["never-intermediate"],
+  syntax: "scss",
+
+  accept: [ {
+    code: `a {
+      @if ($x == 1) {}
+      width: 10px;
+    }`,
+    description: "never-intermediate (no @else, has newline after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {}width: 10px;
+    }`,
+    description: "never-intermediate (no @else, no whitespace after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {} width: 10px;
+    }`,
+    description: "never-intermediate (no @else, has a space after).",
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      }@else {}
+
+      width: 10px;
+    }`,
+    description: "never-intermediate (has @else, no space after).",
+  }, {
+    code: `a {
+      @if ($x == 1) { }@else { }
+
+      width: 10px;
+    }`,
+    description: "never-intermediate (has @else, single-line, no space after).",
+  }, {
+    code: "@if ($x == 1) {}",
+    description: "never-intermediate (single line, nothing after).",
+  }, {
+    // TODO: should warn on this?
+    code: `a {
+      @if ($x == 1) {
+        
+      } @include x;
+    }`,
+    description: "never-intermediate (followed by non-@else at-rule, has space after).",
+  } ],
+
+  reject: [ {
+    code: `a {
+      @if ($x == 1) {
+        
+      } @else {}
+    }`,
+    description: "never-intermediate (has @else, has space after).",
+    message: messages.rejected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      }
+      @else { }
+    }`,
+    description: "never-intermediate (has @else, newline after).",
+    message: messages.rejected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      } 
+      @else { }
+    }`,
+    description: "never-intermediate (has @else, a space and a newline after).",
+    message: messages.rejected,
+    line: 4,
+  }, {
+    code: `a {
+      @if ($x == 1) {
+        
+      }  @else { }
+    }`,
+    description: "never-intermediate (has @else, multiple spaces after).",
+    message: messages.rejected,
+    line: 4,
+  } ],
+})

--- a/src/rules/at-if-closing-brace-space-after/index.js
+++ b/src/rules/at-if-closing-brace-space-after/index.js
@@ -1,0 +1,66 @@
+import { namespace } from "../../utils"
+import { utils } from "stylelint"
+
+export const ruleName = namespace("at-if-closing-brace-space-after")
+
+export const messages = utils.ruleMessages(ruleName, {
+  expected: "Expected single space after \"}\" of @if statement",
+  rejected: "Unexpected space after \"}\" of @if statement",
+})
+
+export default function (expectation) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: [ "always-intermediate", "never-intermediate" ],
+    })
+    if (!validOptions) { return }
+
+    sassConditionalBraceSpaceAfterChecker({ root, result, ruleName, atRuleName: "if", expectation, messages })
+  }
+}
+
+/**
+ * The core logic for this rule. Can be imported by other rules with similar
+ * logic, namely at-else-closing-brace-space-after
+ *
+ * @param {Object} args -- Named arguments object
+ * @param {PostCSS root} args.root
+ * @param {PostCSS result} args.result
+ * @param {String ruleName} args.ruleName - needed for `report` function
+ * @param {String} args.atRuleName - the name of the at-rule to be checked, e.g. "if", "else"
+ * @param {Object} args.messages - returned by stylelint.utils.ruleMessages
+ * @return {undefined} 
+ */
+export function sassConditionalBraceSpaceAfterChecker({ root, result, ruleName, atRuleName, expectation, messages }) {
+  function complain(node, message, index) {
+    utils.report({
+      result,
+      ruleName,
+      node,
+      message,
+      index,
+    })
+  }
+
+  root.walkAtRules(atrule => {
+    // Do nothing if it's not an @if
+    if (atrule.name !== atRuleName) { return }
+
+    const nextNode = atrule.next()
+    const hasSpaceAfter = nextNode && nextNode.raws.before === " "
+    const hasWhiteSpaceAfter = nextNode && nextNode.raws.before !== ""
+    const reportIndex = atrule.toString().length
+
+    // When followed by an @else
+    if (nextNode && nextNode.type === "atrule" && nextNode.name === "else") {
+      // A single space is needed
+      if (expectation === "always-intermediate" && !hasSpaceAfter) {
+        complain(atrule, messages.expected, reportIndex)
+      } else if (expectation === "never-intermediate" && hasWhiteSpaceAfter) {
+        // No whitespace is needed
+        complain(atrule, messages.rejected, reportIndex)
+      }
+    }
+  })
+}

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,6 +1,7 @@
 import atExtendNoMissingPlaceholder from "./at-extend-no-missing-placeholder"
 import atElseClosingBraceNewlineAfter from "./at-else-closing-brace-newline-after"
 import atElseClosingBraceSpaceAfter from "./at-else-closing-brace-space-after"
+import atElseEmptyLineBefore from "./at-else-empty-line-before"
 import atFunctionPattern from "./at-function-pattern"
 import atIfClosingBraceNewlineAfter from "./at-if-closing-brace-newline-after"
 import atIfClosingBraceSpaceAfter from "./at-if-closing-brace-space-after"
@@ -33,7 +34,8 @@ import selectorNoRedundantNestingSelector from "./selector-no-redundant-nesting-
 export default {
   "at-extend-no-missing-placeholder": atExtendNoMissingPlaceholder,
   "at-else-closing-brace-newline-after": atElseClosingBraceNewlineAfter,
-  "at-else-closing-brace-space-after": atElseClosingBraceSpaceAfter,
+  "at-else-closing-brace-space-after": atElseEmptyLineBefore,
+  "at-else-empty-line-before": atElseClosingBraceSpaceAfter,
   "at-function-pattern": atFunctionPattern,
   "at-if-closing-brace-newline-after": atIfClosingBraceNewlineAfter,
   "at-if-closing-brace-space-after": atIfClosingBraceSpaceAfter,

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,5 +1,9 @@
 import atExtendNoMissingPlaceholder from "./at-extend-no-missing-placeholder"
+import atElseClosingBraceNewlineAfter from "./at-else-closing-brace-newline-after"
+import atElseClosingBraceSpaceAfter from "./at-else-closing-brace-space-after"
 import atFunctionPattern from "./at-function-pattern"
+import atIfClosingBraceNewlineAfter from "./at-if-closing-brace-newline-after"
+import atIfClosingBraceSpaceAfter from "./at-if-closing-brace-space-after"
 import atImportNoPartialExtension from "./at-import-no-partial-extension"
 import atImportNoPartialLeadingUnderscore from "./at-import-no-partial-leading-underscore"
 import atImportPartialExtensionBlacklist from "./at-import-partial-extension-blacklist"
@@ -28,7 +32,11 @@ import selectorNoRedundantNestingSelector from "./selector-no-redundant-nesting-
 
 export default {
   "at-extend-no-missing-placeholder": atExtendNoMissingPlaceholder,
+  "at-else-closing-brace-newline-after": atElseClosingBraceNewlineAfter,
+  "at-else-closing-brace-space-after": atElseClosingBraceSpaceAfter,
   "at-function-pattern": atFunctionPattern,
+  "at-if-closing-brace-newline-after": atIfClosingBraceNewlineAfter,
+  "at-if-closing-brace-space-after": atIfClosingBraceSpaceAfter,
   "at-import-no-partial-extension": atImportNoPartialExtension,
   "at-import-no-partial-leading-underscore": atImportNoPartialLeadingUnderscore,
   "at-import-partial-extension-blacklist": atImportPartialExtensionBlacklist,


### PR DESCRIPTION
Implements #82 

These rules with the corresponding options are added (the reasoning and examples are in the issue discussion):
```
"at-if-closing-brace-newline-after": "always-last-in-chain"
"at-if-closing-brace-space-after": "always-intermediate"|"never-intermediate"
"at-else-closing-brace-newline-after": "always-last-in-chain"
"at-else-closing-brace-space-after": "always-intermediate"|"never-intermediate"
"at-else-empty-line-before": "never"
```

I also added the /docs folder, for now it only has [examples/if-else.md](https://github.com/kristerkari/stylelint-scss/blob/if-else-newlines/docs/examples/if-else.md).

There are still cases I belive are unresolved:

- [ ] We can't force `@else if` to always be on the same line. Can be solved by the `never` option to [`at-rule-name-newline-after`](http://stylelint.io/user-guide/rules/at-rule-name-newline-after/) (I'm ok with pushing a PR).
- [x] Disallow an empty line before @else when `at-rule-empty-line-before` has `ignoreAtRules: [ "else" ]`.

@ntwb Please see if the functionality that is complete so far works for you, and if there are any other things we need done.

cc. @kristerkari @jeddy3 