### PR TITLE
Add rule: at-rule-no-unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added: `declaration-nested-properties-no-divided-groups` rule.
 - Added: `ignore: "local"|"global"` to the `dollar-variable-pattern` rule.
 - Added: `dollar-variable-empty-line-before` rule.
+- Added: `at-rule-no-unknown` rule.
 
 # 1.3.4
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Here are stylelint-scss' rules, grouped by the [*thing*](http://apps.workflower.
 - [`at-mixin-argumentless-call-parentheses`](./src/rules/at-mixin-argumentless-call-parentheses/README.md): Require or disallow parentheses in argumentless `@mixin` calls.
 - [`at-mixin-pattern`](./src/rules/at-mixin-pattern/README.md): Specify a pattern for Sass/SCSS-like mixin names.
 
+### `@`-rule
+
+- [`at-rule-no-unknown`](./src/rules/at-rule-no-unknown/README.md): Disallow unknown at-rules. Should be used **instead of** stylelint's [at-rule-no-unknown](http://stylelint.io/user-guide/rules/at-rule-no-unknown/).
+
 ### `$`-variable
 
 - [`dollar-variable-colon-newline-after`](./src/rules/dollar-variable-colon-newline-after/README.md): Require a newline after the colon in `$`-variable declarations.

--- a/src/rules/at-rule-no-unknown/README.md
+++ b/src/rules/at-rule-no-unknown/README.md
@@ -1,0 +1,63 @@
+# at-rule-no-unknown
+
+Disallow unknown at-rules. Should be used **instead of** stylelint's [at-rule-no-unknown](http://stylelint.io/user-guide/rules/at-rule-no-unknown/).
+
+```css
+    @unknown (max-width: 960px) {}
+/** ↑
+ * At-rules like this */
+```
+
+This rule is basically a wrapper around the mentioned core rule, but with added SCSS-specific `@`-directives. So if you use the core rule, `@if`, `@extend` and other Sass-y things will get warnings.
+
+## Options
+
+### `true`
+
+The following patterns are considered warnings:
+
+```css
+@unknown {}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+@function foo () {}
+```
+
+```css
+@While ($i == 1) {}
+```
+
+```css
+@media (max-width: 960px) {}
+```
+
+```css
+@if ($i) {} @else {}
+```
+
+## Optional secondary options
+
+### `ignoreAtRules: ["/regex/", "string"]`
+
+Given:
+
+```js
+["/^my-/", "custom"]
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+@my-at-rule "x.css";
+```
+
+```css
+@my-other-at-rule {}
+```
+
+```css
+@custom {}
+```

--- a/src/rules/at-rule-no-unknown/__tests__/index.js
+++ b/src/rules/at-rule-no-unknown/__tests__/index.js
@@ -1,0 +1,66 @@
+import testRule from "stylelint-test-rule-tape"
+import rule, { ruleName } from ".."
+
+// Not testing for a correct message because it's not convenient to import
+// stylelint's rules messages
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "scss",
+
+  accept: [ {
+    code: "@function foo () {}",
+  }, {
+    code: "@Function foo () { @return 1; }",
+  }, {
+    code: "@extend %p",
+  }, {
+    code: "@While ($i == 1) {}",
+  }, {
+    code: "@if ($i) {}",
+  }, {
+    code: "@if ($i) {} @else {}",
+  } ],
+  
+  reject: [{
+    code: `
+      @funciton floo ($n) {}
+    `,
+    line: 2,
+    description: "",
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ true, { ignoreAtRules: [ "unknown", "/^my-/" ] } ],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "@unknown { }",
+  }, {
+    code: "@Unknown { }",
+  }, {
+    code: "@uNkNoWn { }",
+  }, {
+    code: "@UNKNOWN { }",
+  }, {
+    code: "@my-at-rule { }",
+  }, {
+    code: "@MY-other-at-rule { }",
+  } ],
+
+  reject: [ {
+    code: "@unknown-at-rule { }",
+    line: 1,
+    column: 1,
+  }, {
+    code: "@unknown { @unknown-at-rule { font-size: 14px; } }",
+    line: 1,
+    column: 12,
+  }, {
+    code: "@not-my-at-rule {}",
+    line: 1,
+    column: 1,
+  } ],
+})

--- a/src/rules/at-rule-no-unknown/index.js
+++ b/src/rules/at-rule-no-unknown/index.js
@@ -1,0 +1,25 @@
+import { rules } from "stylelint"
+import { namespace } from "../../utils"
+
+export const ruleName = namespace("at-rule-no-unknown")
+
+// export const messages = utils.ruleMessages(ruleName, {
+  // rejected: (atRule) => `Unexpected unknown at-rule "${atRule}"`,
+// })
+
+const sassAtRules = [
+  "extend", "at-root", "debug",
+  "warn", "error", "if", "else",
+  "for", "each", "while", "mixin",
+  "include", "content", "return", "function",
+]
+
+export default function (on, options) {
+  return (root, result) => {
+    const defaultedOptions = Object.assign({}, options, {
+      ignoreAtRules: sassAtRules.concat(options && options.ignoreAtRules || []),
+    })
+
+    rules["at-rule-no-unknown"](on, defaultedOptions)(root, result)
+  }
+}

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -4,6 +4,7 @@ import atImportNoPartialExtension from "./at-import-no-partial-extension"
 import atImportNoPartialLeadingUnderscore from "./at-import-no-partial-leading-underscore"
 import atImportPartialExtensionBlacklist from "./at-import-partial-extension-blacklist"
 import atImportPartialExtensionWhitelist from "./at-import-partial-extension-whitelist"
+import atRuleNoUnknown from "./at-rule-no-unknown"
 import atMixinArgumentlessCallParentheses from "./at-mixin-argumentless-call-parentheses"
 import atMixinNoArgumentlessCallParentheses from "./at-mixin-no-argumentless-call-parentheses"
 import atMixinPattern from "./at-mixin-pattern"
@@ -36,6 +37,7 @@ export default {
   "at-mixin-argumentless-call-parentheses": atMixinArgumentlessCallParentheses,
   "at-mixin-no-argumentless-call-parentheses": atMixinNoArgumentlessCallParentheses,
   "at-mixin-pattern": atMixinPattern,
+  "at-rule-no-unknown": atRuleNoUnknown,
   "declaration-nested-properties": declarationNestedProperties,
   "declaration-nested-properties-no-divided-groups": declarationNestedPropertiesNoDividedGroups,
   "dollar-variable-colon-newline-after": dollarVariableColonNewlineAfter,


### PR DESCRIPTION
Implements #86. Needed to consider SCSS-specific @-directives as known rules
while being able to disallow all the other non-standard unknown at-rules.

The only issue I couldn't resolve is how to import warning messages from core stylelint rules without hardcoding the path.

*Upd*: maybe postpone this until https://github.com/stylelint/stylelint/pull/2173 gets released and we're able to report from inside this rule (that would also serve the warning message issue from above).