### PR TITLE
allow backslash as a part of valid function name

### DIFF
--- a/src/utils/__tests__/findCommentsInRaws.js
+++ b/src/utils/__tests__/findCommentsInRaws.js
@@ -265,3 +265,51 @@ test("CSS comment, Windows newlines", t => {
     })
     .catch(logError)
 })
+
+test("//-comment, backslash in identifier", t => {
+  t.plan(4)
+
+  postcss()
+    .process(`
+      $foo\bar: 1; // variable
+
+      @function baz\qux() // function
+      {}
+       
+      @mixin quux\corge() // mixin
+      {}
+    `, { syntax: scss })
+    .then(result => {
+      const css = result.root.source.input.css
+      const comments = findCommentsInRaws(css)
+      t.equal(comments.length, 3)
+      t.deepEqual(comments[0].source, { start: 20, end: 30 })
+      t.deepEqual(comments[1].source, { start: 61, end: 71 })
+      t.deepEqual(comments[2].source, { start: 118, end: 125 })
+    })
+    .catch(logError)
+})
+
+test("CSS comment, backslash in identifier", t => {
+  t.plan(4)
+
+  postcss()
+    .process(`
+      $foo\bar: 1; /* variable */
+
+      @function baz\qux() /* function */
+      {}
+       
+      @mixin quux\corge() /* mixin */
+      {}
+    `, { syntax: scss })
+    .then(result => {
+      const css = result.root.source.input.css
+      const comments = findCommentsInRaws(css)
+      t.equal(comments.length, 3)
+      t.deepEqual(comments[0].source, { start: 20, end: 33 })
+      t.deepEqual(comments[1].source, { start: 62, end: 75 })
+      t.deepEqual(comments[2].source, { start: 120, end: 130 })
+    })
+    .catch(logError)
+})

--- a/src/utils/findCommentsInRaws.js
+++ b/src/utils/findCommentsInRaws.js
@@ -75,7 +75,7 @@ export default function findCommentsInRaws(rawString) {
       case "(": {
         if (mode === "comment" || mode === "string") { break }
         const functionName =
-          /(?:^|(?:\n)|(?:\r)|(?:\s-)|[:\s,.(){}*+/%])([a-zA-Z0-9_-]*)$/
+          /(?:^|(?:\n)|(?:\r)|(?:\s-)|[:\s,.(){}*+/%])([\\a-zA-Z0-9_-]*)$/
             .exec(rawString.substring(0, i))[1]
         modesEntered.push({
           mode: functionName === "url" ? "url" : "parens",


### PR DESCRIPTION
[#64 TypeError: Cannot read property '1' of null](https://github.com/kristerkari/stylelint-scss/issues/64) still occurs under certain conditions.

I have struggled with the errors because they had seemed to be fixed. :fearful:
Finally, I noticed that the issue comes from function or mixin name that includes `\` (backslash).

It would be nice stylelint-scss accepts `\` as a part of valid function/mixin name, then the errors won't occur anymore.

ref. sass/libsass/pull/561

---
The following is a scss file that reproduces the error.

test.scss
```scss
$foo\bar: 1;

@function baz\qux() {
}

@mixin quux\corge() {
}
```

## Environment
* Ubuntu 16.04 LTS
* stylelint 7.7.0
* stylelint-scss 1.4.1

---
**Added** (2016/12/27)
This PR needs more modification.
`\` in [at]rule also produces incorrect column poisitions. It seems to be [postcss-scss](https://github.com/postcss/postcss-scss)'s issue rather than stylelint-scss's.