### PR TITLE
Change ruleName in at-mixin-argumentless-call-parentheses to match na…

### DIFF
--- a/src/rules/at-mixin-argumentless-call-parentheses/index.js
+++ b/src/rules/at-mixin-argumentless-call-parentheses/index.js
@@ -1,7 +1,7 @@
 import { utils } from "stylelint"
 import { namespace } from "../../utils"
 
-export const ruleName = namespace("at-mixin-no-argumentless-call-parentheses")
+export const ruleName = namespace("at-mixin-argumentless-call-parentheses")
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: mixin => `Expected parentheses in mixin "${mixin}" call`,


### PR DESCRIPTION
…me of the rule

at-mixin-argumentless-call-parentheses had an extra no- in its ruleName that caused the rule to fail
with an ignore message rather than an error.

Fixes #106