### PR TITLE
at-if-closing-brace-newline-after: support @elseif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# HEAD
+
+- Fixed: `at-if-closing-brace-newline-after`: support `@elseif`.
+
 # 1.4.3
 
 - Fixed: `at-mixin-no-argumentless-call-parentheses` messages

--- a/src/rules/at-if-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/at-if-closing-brace-newline-after/__tests__/index.js
@@ -22,7 +22,7 @@ testRule(rule, {
   }, {
     code: `a {
       @if ($x == 1) {
-        
+
       } @else {}
 
       width: 10px;
@@ -30,11 +30,29 @@ testRule(rule, {
     description: "always-last-in-chain (has @else, no newline after).",
   }, {
     code: `a {
+      @if ($x == 1) {
+
+      } @elseif {
+
+      } @else {}
+
+      width: 10px;
+    }`,
+    description: "always-last-in-chain (has @else and @elseif, no newline after).",
+  }, {
+    code: `a {
       @if ($x == 1) { } @else { }
 
       width: 10px;
     }`,
     description: "always-last-in-chain (has @else, single-line, no newline after).",
+  }, {
+    code: `a {
+      @if ($x == 1) { } @elseif { } @else { }
+
+      width: 10px;
+    }`,
+    description: "always-last-in-chain (has @else and @elseif, single-line, no newline after).",
   }, {
     code: `a {
       @if ($x == 1) { }
@@ -50,7 +68,7 @@ testRule(rule, {
   reject: [ {
     code: `a {
       @if ($x == 1) {
-        
+
       } width: 10px;
     }`,
     description: "always-last-in-chain (has decl on the same line as its closing brace).",
@@ -59,7 +77,7 @@ testRule(rule, {
   }, {
     code: `a {
       @if ($x == 1) {
-        
+
       }
       @else { }
     }`,
@@ -69,7 +87,7 @@ testRule(rule, {
   }, {
     code: `a {
       @if ($x == 1) {
-        
+
       }
 
       @else { }
@@ -80,7 +98,7 @@ testRule(rule, {
   }, {
     code: `a {
       @if ($x == 1) {
-        
+
       } @include x;
     }`,
     description: "always-last-in-chain (followed by non-@else at-rule, no newline after).",

--- a/src/rules/at-if-closing-brace-newline-after/index.js
+++ b/src/rules/at-if-closing-brace-newline-after/index.js
@@ -33,7 +33,7 @@ export default function (expectation) {
  * @param {String ruleName} args.ruleName - needed for `report` function
  * @param {String} args.atRuleName - the name of the at-rule to be checked, e.g. "if", "else"
  * @param {Object} args.messages - returned by stylelint.utils.ruleMessages
- * @return {undefined} 
+ * @return {undefined}
  */
 export function sassConditionalBraceNLAfterChecker({ root, result, ruleName, atRuleName, expectation, messages }) {
   function complain(node, message, index) {
@@ -59,7 +59,7 @@ export function sassConditionalBraceNLAfterChecker({ root, result, ruleName, atR
 
     if (expectation === "always-last-in-chain") {
       // If followed by @else, no newline is needed
-      if (nextNode.type === "atrule" && nextNode.name === "else") {
+      if (nextNode.type === "atrule" && (nextNode.name === "else" || nextNode.name === "elseif")) {
         if (hasNewLinesBeforeNext) { complain(atrule, messages.rejected, reportIndex) }
       } else {
         if (!hasNewLinesBeforeNext) { complain (atrule, messages.expected, reportIndex) }


### PR DESCRIPTION
Add support for `@elseif` for `at-if-closing-brace-newline-after` rule. [It works in Sass](https://github.com/sass/libsass/issues/1060) (but it's not documented).

fixes #107