### PR TITLE
Add rule: at-rule-no-unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# HEAD
+- Added: `at-rule-no-unknown` rule.
+
 # 1.4.4
 
 - Fixed: `at-if-closing-brace-newline-after`: support `@elseif`.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Please also see the [example configs](./docs/examples/) for special cases.
 - [`at-mixin-argumentless-call-parentheses`](./src/rules/at-mixin-argumentless-call-parentheses/README.md): Require or disallow parentheses in argumentless `@mixin` calls.
 - [`at-mixin-pattern`](./src/rules/at-mixin-pattern/README.md): Specify a pattern for Sass/SCSS-like mixin names.
 
+### `@`-rule
+
+- [`at-rule-no-unknown`](./src/rules/at-rule-no-unknown/README.md): Disallow unknown at-rules. Should be used **instead of** stylelint's [at-rule-no-unknown](http://stylelint.io/user-guide/rules/at-rule-no-unknown/).
+
 ### `$`-variable
 
 - [`dollar-variable-colon-newline-after`](./src/rules/dollar-variable-colon-newline-after/README.md): Require a newline after the colon in `$`-variable declarations.

--- a/src/rules/at-rule-no-unknown/README.md
+++ b/src/rules/at-rule-no-unknown/README.md
@@ -1,0 +1,63 @@
+# at-rule-no-unknown
+
+Disallow unknown at-rules. Should be used **instead of** stylelint's [at-rule-no-unknown](http://stylelint.io/user-guide/rules/at-rule-no-unknown/).
+
+```css
+    @unknown (max-width: 960px) {}
+/** ↑
+ * At-rules like this */
+```
+
+This rule is basically a wrapper around the mentioned core rule, but with added SCSS-specific `@`-directives. So if you use the core rule, `@if`, `@extend` and other Sass-y things will get warnings.
+
+## Options
+
+### `true`
+
+The following patterns are considered warnings:
+
+```css
+@unknown {}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+@function foo () {}
+```
+
+```css
+@While ($i == 1) {}
+```
+
+```css
+@media (max-width: 960px) {}
+```
+
+```css
+@if ($i) {} @else {}
+```
+
+## Optional secondary options
+
+### `ignoreAtRules: ["/regex/", "string"]`
+
+Given:
+
+```js
+["/^my-/", "custom"]
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+@my-at-rule "x.css";
+```
+
+```css
+@my-other-at-rule {}
+```
+
+```css
+@custom {}
+```

--- a/src/rules/at-rule-no-unknown/__tests__/index.js
+++ b/src/rules/at-rule-no-unknown/__tests__/index.js
@@ -1,0 +1,69 @@
+import testRule from "stylelint-test-rule-tape"
+import rule, { ruleName, messages } from ".."
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "scss",
+
+  accept: [ {
+    code: "@function foo () {}",
+  }, {
+    code: "@Function foo () { @return 1; }",
+  }, {
+    code: "@extend %p",
+  }, {
+    code: "@While ($i == 1) {}",
+  }, {
+    code: "@if ($i) {}",
+  }, {
+    code: "@if ($i) {} @else {}",
+  } ],
+
+  reject: [{
+    code: `
+      @funciton floo ($n) {}
+    `,
+    line: 2,
+    description: "",
+    message: messages.rejected("@funciton"),
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  config:  [ true, {
+    ignoreAtRules: [ "unknown", "/^my-/" ],
+  } ],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "@unknown { }",
+  }, {
+    code: "@Unknown { }",
+  }, {
+    code: "@uNkNoWn { }",
+  }, {
+    code: "@UNKNOWN { }",
+  }, {
+    code: "@my-at-rule { }",
+  }, {
+    code: "@MY-other-at-rule { }",
+  } ],
+
+  reject: [ {
+    code: "@unknown-at-rule { }",
+    line: 1,
+    column: 1,
+    message: messages.rejected("@unknown-at-rule"),
+  }, {
+    code: "@unknown { @unknown-at-rule { font-size: 14px; } }",
+    line: 1,
+    column: 12,
+  }, {
+    code: "@not-my-at-rule {}",
+    line: 1,
+    column: 1,
+    message: messages.rejected("@not-my-at-rule"),
+  } ],
+})

--- a/src/rules/at-rule-no-unknown/index.js
+++ b/src/rules/at-rule-no-unknown/index.js
@@ -43,7 +43,7 @@ export default function (primaryOption, secondaryOptions) {
     }, (warning) => {
       root.walkAtRules((atRule) => {
         const name = atRule.name
-        if (!ignoreAtRules.includes(name)) {
+        if (ignoreAtRules.indexOf(name) < 0) {
           utils.report({
             message: messages.rejected(`@${name}`),
             ruleName,

--- a/src/rules/at-rule-no-unknown/index.js
+++ b/src/rules/at-rule-no-unknown/index.js
@@ -1,0 +1,59 @@
+import { rules, utils } from "stylelint"
+import { namespace } from "../../utils"
+
+const sassAtRules = [
+  "at-root",
+  "content",
+  "debug",
+  "each",
+  "else",
+  "else if",
+  "error",
+  "extend",
+  "for",
+  "function",
+  "if",
+  "import",
+  "include",
+  "media",
+  "mixin",
+  "return",
+  "warn",
+  "while",
+]
+
+const ruleToCheckAgainst = "at-rule-no-unknown"
+
+const ruleName = namespace(ruleToCheckAgainst)
+
+export const messages = utils.ruleMessages(ruleName, {
+  rejected: rules[ruleToCheckAgainst].messages.rejected,
+})
+
+export default function (primaryOption, secondaryOptions) {
+  return (root, result) => {
+    const optionsAtRules = secondaryOptions && secondaryOptions.ignoreAtRules
+    const ignoreAtRules = sassAtRules.concat(optionsAtRules || [])
+    const defaultedOptions = Object.assign({}, secondaryOptions, { ignoreAtRules })
+
+    utils.checkAgainstRule({
+      ruleName: ruleToCheckAgainst,
+      ruleSettings: [ primaryOption, defaultedOptions ],
+      root,
+    }, (warning) => {
+      root.walkAtRules((atRule) => {
+        const name = atRule.name
+        if (!ignoreAtRules.includes(name)) {
+          utils.report({
+            message: messages.rejected(`@${name}`),
+            ruleName,
+            result,
+            node: warning.node,
+            line: warning.line,
+            column: warning.column,
+          })
+        }
+      })
+    })
+  }
+}

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -12,6 +12,7 @@ import atImportPartialExtensionWhitelist from "./at-import-partial-extension-whi
 import atMixinArgumentlessCallParentheses from "./at-mixin-argumentless-call-parentheses"
 import atMixinNoArgumentlessCallParentheses from "./at-mixin-no-argumentless-call-parentheses"
 import atMixinPattern from "./at-mixin-pattern"
+import atRuleNoUnknown from "./at-rule-no-unknown"
 import declarationNestedProperties from "./declaration-nested-properties"
 import declarationNestedPropertiesNoDividedGroups from "./declaration-nested-properties-no-divided-groups"
 import dollarVariableColonNewlineAfter from "./dollar-variable-colon-newline-after"
@@ -46,6 +47,7 @@ export default {
   "at-mixin-argumentless-call-parentheses": atMixinArgumentlessCallParentheses,
   "at-mixin-no-argumentless-call-parentheses": atMixinNoArgumentlessCallParentheses,
   "at-mixin-pattern": atMixinPattern,
+  "at-rule-no-unknown": atRuleNoUnknown,
   "declaration-nested-properties": declarationNestedProperties,
   "declaration-nested-properties-no-divided-groups": declarationNestedPropertiesNoDividedGroups,
   "dollar-variable-colon-newline-after": dollarVariableColonNewlineAfter,


### PR DESCRIPTION
Addresses #86 by adding a "new" rule extending stylelint's `at-rule-no-unknown` with a built-in list of exceptions including at-rules supported by Sass/SCSS.