### PR TITLE
dollar-variable-colon-newline-after: always allow multiline vars with parens

### DIFF
--- a/src/rules/dollar-variable-colon-newline-after/__tests__/index.js
+++ b/src/rules/dollar-variable-colon-newline-after/__tests__/index.js
@@ -205,6 +205,43 @@ testRule(rule, {
       `,
       description:
         "always-multi-line: should allow multiline variable using newline after colon"
+    },
+    {
+      code: `
+      $map: (
+        foo: 1,
+        bar: 2,
+      );
+      `,
+      description:
+        "always-multi-line: should allow using Sass map without a newline"
+    },
+    {
+      code: `
+      $var: (
+        1 +
+        2 +
+        3
+      );
+      `,
+      description:
+        "always-multi-line: should allow using multiline variable with parens without a newline"
+    },
+    {
+      code: `
+      $foo: 1;
+
+      $foo:
+        2,
+        3;
+
+      $foo: (
+        bar: 1,
+        qux: 2,
+      );
+      `,
+      description:
+        "always-multi-line: should allow using a mix of multiline variables"
     }
   ],
 
@@ -230,33 +267,6 @@ testRule(rule, {
       message: messages.expectedAfterMultiLine(),
       line: 1,
       column: 14
-    },
-    {
-      code: `
-      $map: (
-        foo: 1,
-        bar: 2,
-      );
-      `,
-      description:
-        "always-multi-line: should report when using Sass map without a newline",
-      message: messages.expectedAfterMultiLine(),
-      line: 2,
-      column: 11
-    },
-    {
-      code: `
-      $var: (
-        1 +
-        2 +
-        3
-      );
-      `,
-      description:
-        "always-multi-line: should report when using multiline variable without a newline",
-      message: messages.expectedAfterMultiLine(),
-      line: 2,
-      column: 11
     }
   ]
 });

--- a/src/rules/dollar-variable-colon-newline-after/index.js
+++ b/src/rules/dollar-variable-colon-newline-after/index.js
@@ -30,16 +30,14 @@ export default function(expectation) {
         return;
       }
 
-      if (expectation === "always") {
-        const value = decl.value.trim();
-        const isMultilineVar =
-          value[0] === "(" &&
-          value[value.length - 1] === ")" &&
-          !isSingleLineString(value);
+      const value = decl.value.trim();
+      const isMultilineVarWithParens =
+        value[0] === "(" &&
+        value[value.length - 1] === ")" &&
+        !isSingleLineString(value);
 
-        if (isMultilineVar) {
-          return;
-        }
+      if (isMultilineVarWithParens) {
+        return;
       }
 
       // Get the raw $var, and only that


### PR DESCRIPTION
See discussion in: https://github.com/kristerkari/stylelint-scss/issues/172#issuecomment-369716880

Fixes #172

Please review this @levacic @sindresorhus @AndyOGo