### PR TITLE
Fix crash when at-function-named-arguments encounters trailing commas in function calls

### DIFF
--- a/src/rules/at-function-named-arguments/__tests__/index.js
+++ b/src/rules/at-function-named-arguments/__tests__/index.js
@@ -72,6 +72,16 @@ testRule(rule, {
     {
       code: `
       .b {
+        border: reset(
+          $value: 40px,
+        );
+      }
+      `,
+      description: "Always. Example: trailing comma after last argument."
+    },
+    {
+      code: `
+      .b {
         border: reset($value: 40px, $second-value: 10px, $color: 'black');
       }
       `,

--- a/src/utils/__tests__/parseFunctionArguments.js
+++ b/src/utils/__tests__/parseFunctionArguments.js
@@ -95,6 +95,53 @@ describe("groupByKeyValue", () => {
         { quote: "'", sourceIndex: 49, type: "string", value: "black" }
       ]
     ]);
+    expect(
+      groupByKeyValue([
+        { type: "word", sourceIndex: 6, value: "$value" },
+        {
+          type: "div",
+          sourceIndex: 12,
+          value: ":",
+          before: "",
+          after: " "
+        },
+        { type: "word", sourceIndex: 14, value: "40px" },
+        {
+          type: "div",
+          sourceIndex: 18,
+          value: ",",
+          before: "",
+          after: " "
+        },
+        { type: "word", sourceIndex: 20, value: "$second-value" },
+        {
+          type: "div",
+          sourceIndex: 33,
+          value: ":",
+          before: "",
+          after: " "
+        },
+        { type: "word", sourceIndex: 35, value: "10px" },
+        {
+          type: "div",
+          sourceIndex: 39,
+          value: ",",
+          before: "",
+          after: " "
+        }
+      ])
+    ).toEqual([
+      [
+        { sourceIndex: 6, type: "word", value: "$value" },
+        { after: " ", before: "", sourceIndex: 12, type: "div", value: ":" },
+        { sourceIndex: 14, type: "word", value: "40px" }
+      ],
+      [
+        { sourceIndex: 20, type: "word", value: "$second-value" },
+        { after: " ", before: "", sourceIndex: 33, type: "div", value: ":" },
+        { sourceIndex: 35, type: "word", value: "10px" }
+      ]
+    ]);
   });
 });
 
@@ -142,6 +189,17 @@ describe("parseFunctionArguments", () => {
 
   it("parses multiple args", () => {
     expect(parseFunctionArguments("func(1, 2)")).toEqual([
+      {
+        value: "1"
+      },
+      {
+        value: "2"
+      }
+    ]);
+  });
+
+  it("parses trailing commas", () => {
+    expect(parseFunctionArguments("func(1, 2,)")).toEqual([
       {
         value: "1"
       },

--- a/src/utils/parseFunctionArguments.js
+++ b/src/utils/parseFunctionArguments.js
@@ -6,16 +6,22 @@ export function groupByKeyValue(nodes) {
     return [];
   }
 
-  let i = 0;
+  let groupIndex = 0;
 
-  return nodes.reduce((acc, node) => {
+  return nodes.reduce((acc, node, nodeIndex) => {
     const isComma = node.type === "div" && node.value === ",";
-    if (isComma) {
-      i++;
+    const skipTrailingComma = isComma && nodeIndex === nodes.length - 1;
+
+    if (skipTrailingComma) {
+      return acc;
     }
-    acc[i] = acc[i] || [];
+
+    if (isComma) {
+      groupIndex++;
+    }
+    acc[groupIndex] = acc[groupIndex] || [];
     if (!isComma) {
-      acc[i].push(node);
+      acc[groupIndex].push(node);
     }
     return acc;
   }, []);


### PR DESCRIPTION
When `at-function-named-arguments` is enabled, stylelint crashes when the rule attempts to parse function calls that have a trailing comma (has been [part of Sass since ± 2016](https://github.com/sass/libsass/issues/2070)). For example:

```scss
.b {
  border: reset(
    $value: 40px,
  );
}
```

This will cause the following error:

```
    TypeError: Cannot read property 'key' of undefined

       98 |             case "always": {
    >  99 |               if (arg.key && isScssVarRegExp.test(arg.key)) {
          |                                                    ^
      100 |                 return;
      101 |               }

      at src/rules/at-function-named-arguments/index.js:99:52
      [...]
```

---

The error is caused by `groupByKeyValue` of  `parseFunctionArguments`, which creates an empty group when seeing the comma. It seems like a simple fix would be to ignore the comma if it is trailing, this seems to work based on the tests I added.