### PR TITLE
Fix link markup in contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,6 @@ We communicate via [issues](https://github.com/kristerkari/stylelint-scss/issues
 
 stylelint-scss is a plugin for stylelint, so it adopts and uses as much of stylelint's guidelines as it can.
 
-* [Contributing guidelines] (https://github.com/stylelint/stylelint/blob/master/CONTRIBUTING.md) - is a general guidelines of how to communicate with the other developers here.
-* [Working on rules] (https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md). stylelint-scss' rules are written just as stylelint's rules, except that all rules need to be namespaced using the `namespace` utility function.
-* [Testing rules] (https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rule-testers.md) | [Running tests](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#running-tests). Always provide as many tests as you can.
+* [Contributing guidelines](https://github.com/stylelint/stylelint/blob/master/CONTRIBUTING.md) - is a general guidelines of how to communicate with the other developers here.
+* [Working on rules](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md). stylelint-scss' rules are written just as stylelint's rules, except that all rules need to be namespaced using the `namespace` utility function.
+* [Testing rules](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rule-testers.md) | [Running tests](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#running-tests). Always provide as many tests as you can.


### PR DESCRIPTION
The links were not rendering correctly because of the extra spaces.