### PR TITLE
Account for hyphens in function and mixin names

### DIFF
--- a/src/rules/at-function-parentheses-space-before/__tests__/index.js
+++ b/src/rules/at-function-parentheses-space-before/__tests__/index.js
@@ -41,6 +41,13 @@ testRule(rule, {
       }
     `,
       description: "Not a SCSS function, skipping."
+    },
+    {
+      code: `
+      @function foo-bar () {
+      }
+    `,
+      description: "No params, hyphenated name."
     }
   ],
 
@@ -86,6 +93,19 @@ testRule(rule, {
       line: 2,
       message: messages.expectedBefore(),
       description: "Extra spaces after @function."
+    },
+    {
+      code: `
+      @function foo-bar($n) {
+      }
+    `,
+      fixed: `
+      @function foo-bar ($n) {
+      }
+    `,
+      line: 2,
+      message: messages.expectedBefore(),
+      description: "No space before parentheses, hyphenated name."
     }
   ]
 });
@@ -131,6 +151,13 @@ testRule(rule, {
       }
     `,
       description: "Not a SCSS function, skipping."
+    },
+    {
+      code: `
+      @function foo-bar() {
+      }
+    `,
+      description: "No params, hyphenated name."
     }
   ],
 
@@ -176,6 +203,19 @@ testRule(rule, {
       line: 2,
       message: messages.rejectedBefore(),
       description: "Multiple spaces before parentheses."
+    },
+    {
+      code: `
+      @function foo-bar ($n) {
+      }
+    `,
+      fixed: `
+      @function foo-bar($n) {
+      }
+    `,
+      line: 2,
+      message: messages.rejectedBefore(),
+      description: "Single space before parentheses, hyphenated name."
     }
   ]
 });

--- a/src/rules/at-function-parentheses-space-before/index.js
+++ b/src/rules/at-function-parentheses-space-before/index.js
@@ -20,7 +20,7 @@ export default function(value, _, context) {
       return;
     }
 
-    const match = /^(\w+)\s*?\(/;
+    const match = /^([\w-]+)\s*?\(/;
     const replacement = value === "always" ? "$1 (" : "$1(";
 
     const checker = whitespaceChecker("space", value, messages).before;

--- a/src/rules/at-mixin-parentheses-space-before/__tests__/index.js
+++ b/src/rules/at-mixin-parentheses-space-before/__tests__/index.js
@@ -48,6 +48,13 @@ testRule(rule, {
       }
     `,
       description: "Not a SCSS mixin, skipping."
+    },
+    {
+      code: `
+      @mixin foo-bar () {
+      }
+    `,
+      description: "No params with parentheses, hyphenated name."
     }
   ],
 
@@ -93,6 +100,19 @@ testRule(rule, {
       line: 2,
       message: messages.expectedBefore(),
       description: "Extra spaces after @mixin."
+    },
+    {
+      code: `
+      @mixin foo-bar($n) {
+      }
+    `,
+      fixed: `
+      @mixin foo-bar ($n) {
+      }
+    `,
+      line: 2,
+      message: messages.expectedBefore(),
+      description: "No space before parentheses, hyphenated name."
     }
   ]
 });
@@ -145,6 +165,13 @@ testRule(rule, {
       }
     `,
       description: "Not a SCSS mixin, skipping."
+    },
+    {
+      code: `
+      @mixin foo-bar() {
+      }
+    `,
+      description: "No params with parentheses, hyphenated name."
     }
   ],
 
@@ -190,6 +217,19 @@ testRule(rule, {
       line: 2,
       message: messages.rejectedBefore(),
       description: "Multiple spaces before parentheses."
+    },
+    {
+      code: `
+      @mixin foo-bar ($n) {
+      }
+    `,
+      fixed: `
+      @mixin foo-bar($n) {
+      }
+    `,
+      line: 2,
+      message: messages.rejectedBefore(),
+      description: "Single space before parentheses, hyphenated name."
     }
   ]
 });

--- a/src/rules/at-mixin-parentheses-space-before/index.js
+++ b/src/rules/at-mixin-parentheses-space-before/index.js
@@ -20,7 +20,7 @@ export default function(value, _, context) {
       return;
     }
 
-    const match = /^(\w+)\s*?\(/;
+    const match = /^([\w-]+)\s*?\(/;
     const replacement = value === "always" ? "$1 (" : "$1(";
 
     const checker = whitespaceChecker("space", value, messages).before;


### PR DESCRIPTION
Current rules won’t fix cases where function or mixin name uses hyphens, e.g.:

```scss
@function first-column-percentage-width($ratio) {
	@return percentage(nth($ratio, 1) / (nth($ratio, 2) - nth($ratio, 1)));
}
```