### PR TITLE
Initial work on "at-mixin-argumentless-call-parentheses" fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Please also see the [example configs](./docs/examples/) for special cases.
 
 ### `@`-mixin
 
-- [`at-mixin-argumentless-call-parentheses`](./src/rules/at-mixin-argumentless-call-parentheses/README.md): Require or disallow parentheses in argumentless `@mixin` calls.
+- [`at-mixin-argumentless-call-parentheses`](./src/rules/at-mixin-argumentless-call-parentheses/README.md): Require or disallow parentheses in argumentless `@mixin` calls (Autofixable).
 - [`at-mixin-named-arguments`](./src/rules/at-mixin-named-arguments/README.md): Require named parameters in at-mixin call rule.
 - [`at-mixin-parentheses-space-before`](./src/rules/at-mixin-parentheses-space-before/README.md): Require or disallow a space before `@mixin` parentheses (Autofixable).
 - [`at-mixin-pattern`](./src/rules/at-mixin-pattern/README.md): Specify a pattern for Sass/SCSS-like mixin names.

--- a/src/rules/at-else-empty-line-before/README.md
+++ b/src/rules/at-else-empty-line-before/README.md
@@ -63,3 +63,7 @@ a {
   }
 }
 ```
+
+## Caveats
+
+If you use autofix, this rule could clash with [`at-mixin-parentheses-space-before`](https://github.com/kristerkari/stylelint-scss/tree/master/src/rules/at-mixin-parentheses-space-before) rule.

--- a/src/rules/at-mixin-argumentless-call-parentheses/README.md
+++ b/src/rules/at-mixin-argumentless-call-parentheses/README.md
@@ -8,6 +8,8 @@ Require or disallow parentheses in argumentless `@mixin` calls.
  *                 Such mixin calls */
 ```
 
+The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/src/rules/at-mixin-argumentless-call-parentheses/__tests__/index.js
+++ b/src/rules/at-mixin-argumentless-call-parentheses/__tests__/index.js
@@ -4,6 +4,7 @@ testRule(rule, {
   ruleName,
   config: ["never"],
   syntax: "scss",
+  fix: true,
 
   accept: [
     {
@@ -31,6 +32,9 @@ testRule(rule, {
       code: `
       @include foo () ;
     `,
+      fixed: `
+      @include foo ;
+    `,
       line: 2,
       message: messages.rejected("foo"),
       description: "With parens, no space between them."
@@ -38,6 +42,9 @@ testRule(rule, {
     {
       code: `
       @include foo ( ) ;
+    `,
+      fixed: `
+      @include foo ;
     `,
       line: 2,
       message: messages.rejected("foo"),
@@ -47,6 +54,9 @@ testRule(rule, {
       code: `
       @include foo( ) ;
     `,
+      fixed: `
+      @include foo ;
+    `,
       line: 2,
       message: messages.rejected("foo"),
       description: "With parens, no space before and space between them"
@@ -55,6 +65,9 @@ testRule(rule, {
       code: `
       @include foo(
       ) ;
+    `,
+      fixed: `
+      @include foo ;
     `,
       line: 2,
       message: messages.rejected("foo"),
@@ -67,6 +80,7 @@ testRule(rule, {
   ruleName,
   config: ["always"],
   syntax: "scss",
+  fix: true,
 
   accept: [
     {
@@ -101,6 +115,9 @@ testRule(rule, {
       code: `
       @include foo;
     `,
+      fixed: `
+      @include foo ();
+    `,
       line: 2,
       message: messages.expected("foo"),
       description: "No parens."
@@ -109,6 +126,9 @@ testRule(rule, {
       code: `
       @include foo ;
     `,
+      fixed: `
+      @include foo () ;
+    `,
       line: 2,
       message: messages.expected("foo"),
       description: "No parens; a space after mixin name in a call."
@@ -116,6 +136,9 @@ testRule(rule, {
     {
       code: `
       @include foo
+    `,
+      fixed: `
+      @include foo ()
     `,
       line: 2,
       message: messages.expected("foo"),

--- a/src/rules/at-mixin-argumentless-call-parentheses/index.js
+++ b/src/rules/at-mixin-argumentless-call-parentheses/index.js
@@ -9,7 +9,7 @@ export const messages = utils.ruleMessages(ruleName, {
     `Unexpected parentheses in argumentless mixin "${mixin}" call`
 });
 
-export default function(value) {
+export default function(value, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: value,
@@ -29,6 +29,15 @@ export default function(value) {
       }
       // If it is "Always use parens"
       if (value === "always" && mixinCall.params.search(/\(/) !== -1) {
+        return;
+      }
+
+      if (context.fix) {
+        if (value === "always") {
+          mixinCall.params = `${mixinCall.params} ()`;
+        } else {
+          mixinCall.params = mixinCall.params.replace(/\s*\([\s\S]*?\)$/, "");
+        }
         return;
       }
 


### PR DESCRIPTION
This PR adds fix functionality to `at-mixin-argumentless-call-parentheses`. There is one problem, though: it should also depend on `at-mixin-parentheses-space-before` rule for spacing but currently there is no way to check against other rule. There is [`stylelint.utils.checkAgainstRule`](https://stylelint.io/developer-guide/plugins/#stylelintutilscheckagainstrule) helper utility, but it doesn’t know about other SCSS rules since [Jest Stylelint setup works only for one rule](https://github.com/kristerkari/stylelint-scss/blob/69a4c625009fde200c54556d11a3f18fa34cf29c/jest-setup.js#L23-L29). Does it make sense to upgrade Jest config to allow additional configuration to account for these changes?