### PR TITLE
Use eslint-config-stylelint

### DIFF
--- a/babel-jest.js
+++ b/babel-jest.js
@@ -1,14 +1,14 @@
-"use strict"; // eslint-disable-line
+"use strict"; // eslint-disable-line strict
 
 /**
-               * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
-               *
-               * This source code is licensed under the BSD-style license found in the
-               * LICENSE file in the root directory of this source tree. An additional grant
-               * of patent rights can be found in the PATENTS file in the same directory.
-               *
-               * 
-               */
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *
+ */
 
 const crypto = require("crypto");
 const fs = require("fs");
@@ -29,6 +29,7 @@ const createTransformer = options => {
   const getBabelRC = filename => {
     const paths = [];
     let directory = filename;
+
     while (directory !== (directory = path.dirname(directory))) {
       if (cache[directory]) {
         break;
@@ -36,20 +37,26 @@ const createTransformer = options => {
 
       paths.push(directory);
       const configFilePath = path.join(directory, BABELRC_FILENAME);
+
       if (fs.existsSync(configFilePath)) {
         cache[directory] = fs.readFileSync(configFilePath, "utf8");
         break;
       }
+
       const configJsFilePath = path.join(directory, BABELRC_JS_FILENAME);
+
       if (fs.existsSync(configJsFilePath)) {
         // $FlowFixMe
         cache[directory] = JSON.stringify(require(configJsFilePath));
         break;
       }
+
       const packageJsonFilePath = path.join(directory, PACKAGE_JSON);
+
       if (fs.existsSync(packageJsonFilePath)) {
         // $FlowFixMe
         const packageJsonFileContents = require(packageJsonFilePath);
+
         if (packageJsonFileContents[BABEL_CONFIG_KEY]) {
           cache[directory] = JSON.stringify(
             packageJsonFileContents[BABEL_CONFIG_KEY]
@@ -60,6 +67,7 @@ const createTransformer = options => {
       }
     }
     paths.forEach(directoryPath => (cache[directoryPath] = cache[directory]));
+
     return cache[directory] || "";
   };
 
@@ -76,6 +84,7 @@ const createTransformer = options => {
     canInstrument: true,
     getCacheKey(fileData, filename, configString, _ref) {
       const instrument = _ref.instrument;
+
       return crypto
         .createHash("md5")
         .update(THIS_FILE)
@@ -99,6 +108,7 @@ const createTransformer = options => {
       }
 
       const theseOptions = Object.assign({ filename }, options);
+
       if (transformOptions && transformOptions.instrument) {
         // theseOptions.auxiliaryCommentBefore = ' istanbul ignore next ';
         // Copied from jest-runtime transform.js

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,4 +1,4 @@
-"use strict"; // eslint-disable-line
+"use strict"; // eslint-disable-line strict
 
 const _ = require("lodash");
 const stylelint = require("stylelint");
@@ -20,7 +20,7 @@ global.testRule = (rule, schema) => {
     }
   });
 
-  describe(schema.ruleName, () => {
+  describe(`${schema.ruleName}`, () => {
     const stylelintConfig = {
       plugins: ["./src"],
       rules: {
@@ -42,6 +42,7 @@ global.testRule = (rule, schema) => {
 
             return stylelint.lint(options).then(output => {
               expect(output.results[0].warnings).toEqual([]);
+
               if (!schema.fix) {
                 return;
               }
@@ -152,7 +153,7 @@ global.testConfig = input => {
         const invalidOptionWarnings = data.results[0].invalidOptionWarnings;
 
         if (input.valid) {
-          expect(invalidOptionWarnings.length).toBe(0);
+          expect(invalidOptionWarnings).toHaveLength(0);
         } else {
           expect(invalidOptionWarnings[0].text).toBe(input.message);
         }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-preset-jest": "^23.2.0",
     "coveralls": "^3.0.2",
     "eslint": "^5.8.0",
-    "eslint-config-stylelint": "^9.0.0",
+    "eslint-config-stylelint": "^10.0.0",
     "eslint-plugin-lodash": "^3.1.0",
     "eslint-plugin-sort-requires": "^2.1.0",
     "husky": "^1.1.3",
@@ -49,7 +49,7 @@
     "node": ">=6"
   },
   "eslintConfig": {
-    "extends": "eslint:recommended",
+    "extends": ["eslint:recommended", "stylelint"],
     "parserOptions": {
       "sourceType": "module",
       "ecmaVersion": 6
@@ -89,7 +89,11 @@
       "lodash/no-extra-args": "error",
       "lodash/no-unbound-this": "error",
       "lodash/unwrap": "error",
-      "lodash/preferred-alias": "error"
+      "lodash/preferred-alias": "error",
+      "node/no-unsupported-features/es-syntax": ["error", {
+        "version": ">=6.0.0",
+        "ignores": ["modules"]
+      }]
     }
   },
   "files": [

--- a/src/rules/at-else-closing-brace-newline-after/index.js
+++ b/src/rules/at-else-closing-brace-newline-after/index.js
@@ -28,6 +28,7 @@ export default function(expectation, options, context) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }

--- a/src/rules/at-else-closing-brace-space-after/index.js
+++ b/src/rules/at-else-closing-brace-space-after/index.js
@@ -15,6 +15,7 @@ export default function(expectation, _, context) {
       actual: expectation,
       possible: ["always-intermediate", "never-intermediate"]
     });
+
     if (!validOptions) {
       return;
     }

--- a/src/rules/at-else-empty-line-before/index.js
+++ b/src/rules/at-else-empty-line-before/index.js
@@ -13,6 +13,7 @@ export default function(expectation, _, context) {
       actual: expectation,
       possible: ["never"]
     });
+
     if (!validOptions) {
       return;
     }
@@ -31,6 +32,7 @@ export default function(expectation, _, context) {
 
       if (context.fix) {
         atrule.raws.before = " ";
+
         return;
       }
 

--- a/src/rules/at-else-if-parentheses-space-before/index.js
+++ b/src/rules/at-else-if-parentheses-space-before/index.js
@@ -16,6 +16,7 @@ export default function(value, _, context) {
       actual: value,
       possible: ["always", "never"]
     });
+
     if (!validOptions) {
       return;
     }
@@ -24,6 +25,7 @@ export default function(value, _, context) {
     const replacement = value === "always" ? "if (" : "if(";
 
     const checker = whitespaceChecker("space", value, messages).before;
+
     root.walkAtRules("else", decl => {
       // return early if the else-if statement is not surrounded by parentheses
       if (!match.test(decl.params)) {

--- a/src/rules/at-extend-no-missing-placeholder/index.js
+++ b/src/rules/at-extend-no-missing-placeholder/index.js
@@ -11,6 +11,7 @@ export const messages = utils.ruleMessages(ruleName, {
 export default function(actual) {
   return function(root, result) {
     const validOptions = utils.validateOptions(result, ruleName, { actual });
+
     if (!validOptions) {
       return;
     }

--- a/src/rules/at-function-named-arguments/index.js
+++ b/src/rules/at-function-named-arguments/index.js
@@ -35,6 +35,7 @@ export default function(expectation, options) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }
@@ -65,6 +66,7 @@ export default function(expectation, options) {
             }
 
             const parts = f.split("/");
+
             return new RegExp(parts[1], parts[2] || "").test(node.value);
           });
 

--- a/src/rules/at-function-parentheses-space-before/index.js
+++ b/src/rules/at-function-parentheses-space-before/index.js
@@ -16,6 +16,7 @@ export default function(value, _, context) {
       actual: value,
       possible: ["always", "never"]
     });
+
     if (!validOptions) {
       return;
     }
@@ -24,9 +25,11 @@ export default function(value, _, context) {
     const replacement = value === "always" ? "$1 (" : "$1(";
 
     const checker = whitespaceChecker("space", value, messages).before;
+
     root.walkAtRules("function", decl => {
       if (context.fix) {
         decl.params = decl.params.replace(match, replacement);
+
         return;
       }
 

--- a/src/rules/at-function-pattern/index.js
+++ b/src/rules/at-function-pattern/index.js
@@ -14,6 +14,7 @@ export default function(pattern) {
       actual: pattern,
       possible: [isRegExp, isString]
     });
+
     if (!validOptions) {
       return;
     }
@@ -27,6 +28,7 @@ export default function(pattern) {
 
       // Stripping the function of its arguments
       const funcName = decl.params.replace(/(\s*?)\((?:\s|\S)*\)/g, "");
+
       if (regexpPattern.test(funcName)) {
         return;
       }

--- a/src/rules/at-if-closing-brace-newline-after/index.js
+++ b/src/rules/at-if-closing-brace-newline-after/index.js
@@ -26,6 +26,7 @@ export default function(expectation, options, context) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }
@@ -66,9 +67,11 @@ export function sassConditionalBraceNLAfterChecker({
   options
 }) {
   const shouldFix = context.fix && (!options || options.disableFix !== true);
+
   function complain(node, message, index, fixValue) {
     if (shouldFix) {
       node.next().raws.before = fixValue;
+
       return;
     }
 
@@ -88,6 +91,7 @@ export function sassConditionalBraceNLAfterChecker({
     }
 
     const nextNode = atrule.next();
+
     if (!nextNode) {
       return;
     }

--- a/src/rules/at-if-closing-brace-space-after/index.js
+++ b/src/rules/at-if-closing-brace-space-after/index.js
@@ -14,6 +14,7 @@ export default function(expectation, _, context) {
       actual: expectation,
       possible: ["always-intermediate", "never-intermediate"]
     });
+
     if (!validOptions) {
       return;
     }
@@ -54,6 +55,7 @@ export function sassConditionalBraceSpaceAfterChecker({
   function complain(node, message, index, fixValue) {
     if (context.fix) {
       node.next().raws.before = fixValue;
+
       return;
     }
 

--- a/src/rules/at-import-no-partial-leading-underscore/index.js
+++ b/src/rules/at-import-no-partial-leading-underscore/index.js
@@ -10,6 +10,7 @@ export const messages = utils.ruleMessages(ruleName, {
 export default function(actual) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, { actual });
+
     if (!validOptions) {
       return;
     }

--- a/src/rules/at-import-partial-extension-blacklist/index.js
+++ b/src/rules/at-import-partial-extension-blacklist/index.js
@@ -11,11 +11,13 @@ export const messages = utils.ruleMessages(ruleName, {
 
 export default function(blacklistOption) {
   const blacklist = [].concat(blacklistOption);
+
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: blacklistOption,
       possible: [isString, isRegExp]
     });
+
     if (!validOptions) {
       return;
     }

--- a/src/rules/at-import-partial-extension-whitelist/index.js
+++ b/src/rules/at-import-partial-extension-whitelist/index.js
@@ -11,11 +11,13 @@ export const messages = utils.ruleMessages(ruleName, {
 
 export default function(whitelistOption) {
   const whitelist = [].concat(whitelistOption);
+
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: whitelistOption,
       possible: [isString, isRegExp]
     });
+
     if (!validOptions) {
       return;
     }

--- a/src/rules/at-mixin-argumentless-call-parentheses/index.js
+++ b/src/rules/at-mixin-argumentless-call-parentheses/index.js
@@ -15,6 +15,7 @@ export default function(value, _, context) {
       actual: value,
       possible: ["always", "never"]
     });
+
     if (!validOptions) {
       return;
     }
@@ -27,6 +28,7 @@ export default function(value, _, context) {
       ) {
         return;
       }
+
       // If it is "Always use parens"
       if (value === "always" && mixinCall.params.search(/\(/) !== -1) {
         return;
@@ -38,6 +40,7 @@ export default function(value, _, context) {
         } else {
           mixinCall.params = mixinCall.params.replace(/\s*\([\s\S]*?\)$/, "");
         }
+
         return;
       }
 

--- a/src/rules/at-mixin-named-arguments/index.js
+++ b/src/rules/at-mixin-named-arguments/index.js
@@ -28,6 +28,7 @@ export default function(expectation, options) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }

--- a/src/rules/at-mixin-parentheses-space-before/index.js
+++ b/src/rules/at-mixin-parentheses-space-before/index.js
@@ -16,6 +16,7 @@ export default function(value, _, context) {
       actual: value,
       possible: ["always", "never"]
     });
+
     if (!validOptions) {
       return;
     }
@@ -24,9 +25,11 @@ export default function(value, _, context) {
     const replacement = value === "always" ? "$1 (" : "$1(";
 
     const checker = whitespaceChecker("space", value, messages).before;
+
     root.walkAtRules("mixin", decl => {
       if (context.fix) {
         decl.params = decl.params.replace(match, replacement);
+
         return;
       }
 

--- a/src/rules/at-mixin-pattern/index.js
+++ b/src/rules/at-mixin-pattern/index.js
@@ -14,6 +14,7 @@ export default function(pattern) {
       actual: pattern,
       possible: [isRegExp, isString]
     });
+
     if (!validOptions) {
       return;
     }
@@ -27,6 +28,7 @@ export default function(pattern) {
 
       // Stripping the mixin of its arguments
       const mixinName = decl.params.replace(/(\s*?)\((?:\s|\S)*\)/g, "");
+
       if (regexpPattern.test(mixinName)) {
         return;
       }

--- a/src/rules/at-rule-no-unknown/index.js
+++ b/src/rules/at-rule-no-unknown/index.js
@@ -47,6 +47,7 @@ export default function(primaryOption, secondaryOptions) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }
@@ -66,6 +67,7 @@ export default function(primaryOption, secondaryOptions) {
       warning => {
         root.walkAtRules(atRule => {
           const name = atRule.name;
+
           if (ignoreAtRules.indexOf(name) < 0) {
             utils.report({
               message: messages.rejected(`@${name}`),

--- a/src/rules/declaration-nested-properties-no-divided-groups/__tests__/index.js
+++ b/src/rules/declaration-nested-properties-no-divided-groups/__tests__/index.js
@@ -127,7 +127,8 @@ test("2 groups of the same namespace.", () => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expected("background"));
       expect(warnings[0].line).toBe(3);
       expect(warnings[0].column).toBe(9);
@@ -159,7 +160,8 @@ test("3 groups, 1 and 3 has the same namespace", () => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expected("background"));
       expect(warnings[0].line).toBe(3);
       expect(warnings[1].line).toBe(10);
@@ -190,7 +192,8 @@ test("3 groups of the same namespace", () => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
       expect(warnings[0].text).toBe(messages.expected("background"));
       expect(warnings[0].line).toBe(3);
       expect(warnings[1].text).toBe(messages.expected("background"));

--- a/src/rules/declaration-nested-properties-no-divided-groups/index.js
+++ b/src/rules/declaration-nested-properties-no-divided-groups/index.js
@@ -15,6 +15,7 @@ export default function(expectation) {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation
     });
+
     if (!validOptions) {
       return;
     }
@@ -31,13 +32,16 @@ export default function(expectation) {
         if (decl.type !== "rule") {
           return;
         }
+
         const testForProp = parseNestedPropRoot(decl.selector);
 
         if (testForProp && testForProp.propName !== undefined) {
           const ns = testForProp.propName.value;
+
           if (!nestedGroups.hasOwnProperty(ns)) {
             nestedGroups[ns] = [];
           }
+
           nestedGroups[ns].push(decl);
         }
       });
@@ -47,6 +51,7 @@ export default function(expectation) {
         if (nestedGroups[namespace].length === 1) {
           return;
         }
+
         nestedGroups[namespace].forEach(group => {
           utils.report({
             message: messages.expected(namespace),

--- a/src/rules/declaration-nested-properties/__tests__/index.js
+++ b/src/rules/declaration-nested-properties/__tests__/index.js
@@ -1,6 +1,5 @@
-import rule, { ruleName, messages } from "../";
-
 import postcss from "postcss";
+import rule, { messages, ruleName } from "../";
 
 function logError(err) {
   console.log(err.stack); // eslint-disable-line no-console
@@ -52,7 +51,8 @@ test("{ always } Simple test: background-color, background-repeat", () => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expected("background-color"));
       expect(warnings[0].line).toBe(3);
       expect(warnings[0].column).toBe(9);
@@ -76,7 +76,8 @@ test("{ always } background-color, background-repeat separated by at-rule", () =
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
       expect(warnings[0].text).toBe(messages.expected("background-color"));
       expect(warnings[0].line).toBe(3);
       expect(warnings[0].column).toBe(9);
@@ -103,7 +104,8 @@ test("{ always } one `background` in nested form", () => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
     })
     .catch(logError);
 });
@@ -124,7 +126,8 @@ test("{ always } nested `background` and background-position", () => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
     })
     .catch(logError);
 });
@@ -145,7 +148,8 @@ test("{ always } `prop:    value {nested} prop-v: value`.", () => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
     })
     .catch(logError);
 });
@@ -166,7 +170,8 @@ test("{ always } `prop  :  value {nested} prop-v: value`.", () => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
     })
     .catch(logError);
 });
@@ -189,7 +194,8 @@ test("{ always, except: only-of-namespace } background-color only", () => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
     })
     .catch(logError);
 });
@@ -209,7 +215,8 @@ test("{ always, except: only-of-namespace } background-color, background-repeat 
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expected("background-color"));
       expect(warnings[0].line).toBe(3);
       expect(warnings[0].column).toBe(9);
@@ -236,7 +243,8 @@ test("{ always, except: only-of-namespace } `background:red`, one rule inside", 
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
     })
     .catch(logError);
 });
@@ -257,12 +265,13 @@ test("{ always, except: only-of-namespace } background, two rules inside", () =>
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
     })
     .catch(logError);
 });
 
-test("{ always, except: only-of-namespace } `background:red`, one rule inside", () => {
+test("{ always, except: only-of-namespace } `background:red`, one rule inside 2", () => {
   expect.assertions(2);
   postcss([rule("always", { except: "only-of-namespace" })])
     .process(
@@ -279,7 +288,8 @@ test("{ always, except: only-of-namespace } `background:red`, one rule inside", 
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
       expect(warnings[0].line).toBe(7);
     })
     .catch(logError);
@@ -300,7 +310,8 @@ test("{ always, except: only-of-namespace } `prop: value`, one rule inside", () 
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
       expect(warnings[0].text).toBe(messages.rejected("background"));
     })
     .catch(logError);
@@ -324,7 +335,8 @@ test("{ always, except: only-of-namespace } `prop:`, one rule X2", () => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.rejected("background"));
       expect(warnings[0].line).toBe(3);
       expect(warnings[1].text).toBe(messages.rejected("background"));

--- a/src/rules/declaration-nested-properties/index.js
+++ b/src/rules/declaration-nested-properties/index.js
@@ -30,6 +30,7 @@ export default function(expectation, options) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }
@@ -55,11 +56,14 @@ export default function(expectation, options) {
             // Add simple namespaced prop decls to warningCandidates.ns
             // (prop names with browser prefixes are ignored)
             const seekNamespace = /^([a-zA-Z0-9]+)-/.exec(prop);
+
             if (seekNamespace && seekNamespace[1]) {
               const ns = seekNamespace[1];
+
               if (!warningCandidates.hasOwnProperty(ns)) {
                 warningCandidates[ns] = [];
               }
+
               warningCandidates[ns].push({ node: decl });
             }
           }
@@ -72,9 +76,11 @@ export default function(expectation, options) {
 
             if (testForProp && testForProp.propName !== undefined) {
               const ns = testForProp.propName.value;
+
               if (!warningCandidates.hasOwnProperty(ns)) {
                 warningCandidates[ns] = [];
               }
+
               warningCandidates[ns].push({
                 node: decl,
                 nested: true

--- a/src/rules/dollar-variable-colon-newline-after/index.js
+++ b/src/rules/dollar-variable-colon-newline-after/index.js
@@ -17,6 +17,7 @@ export const messages = utils.ruleMessages(ruleName, {
 
 export default function(expectation, options, context) {
   const checker = whitespaceChecker("newline", expectation, messages);
+
   return (root, result) => {
     const validOptions = utils.validateOptions(
       result,
@@ -33,6 +34,7 @@ export default function(expectation, options, context) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }
@@ -64,6 +66,7 @@ export default function(expectation, options, context) {
         if (propPlusColon[i] !== ":") {
           continue;
         }
+
         const indexToCheck =
           propPlusColon.substr(propPlusColon[i], 3) === "/*"
             ? propPlusColon.indexOf("*/", i) + 1
@@ -86,6 +89,7 @@ export default function(expectation, options, context) {
                 /:(.*)$/,
                 `:${context.newline}${nextLinePrefix}`
               );
+
               return;
             }
 

--- a/src/rules/dollar-variable-colon-space-after/index.js
+++ b/src/rules/dollar-variable-colon-space-after/index.js
@@ -18,11 +18,13 @@ export const messages = utils.ruleMessages(ruleName, {
 
 export default function(expectation, _, context) {
   const checker = whitespaceChecker("space", expectation, messages);
+
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
       possible: ["always", "never", "always-single-line", "at-least-one-space"]
     });
+
     if (!validOptions) {
       return;
     }
@@ -63,10 +65,12 @@ export function variableColonSpaceChecker({
 
       if (position === "before") {
         const replacement = expectation === "never" ? ":" : " :";
+
         decl.raws.between = decl.raws.between.replace(/\s*:/, replacement);
       } else if (position === "after") {
         const match = expectation === "at-least-one-space" ? /:(?! )/ : /:\s*/;
         const replacement = expectation === "never" ? ":" : ": ";
+
         decl.raws.between = decl.raws.between.replace(match, replacement);
       }
 
@@ -83,6 +87,7 @@ export function variableColonSpaceChecker({
       if (propPlusColon[i] !== ":") {
         continue;
       }
+
       locationChecker({
         source: propPlusColon,
         index: i,

--- a/src/rules/dollar-variable-colon-space-before/index.js
+++ b/src/rules/dollar-variable-colon-space-before/index.js
@@ -11,11 +11,13 @@ export const messages = utils.ruleMessages(ruleName, {
 
 export default function(expectation, _, context) {
   const checker = whitespaceChecker("space", expectation, messages);
+
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
       possible: ["always", "never"]
     });
+
     if (!validOptions) {
       return;
     }

--- a/src/rules/dollar-variable-empty-line-before/index.js
+++ b/src/rules/dollar-variable-empty-line-before/index.js
@@ -35,6 +35,7 @@ export default function(expectation, options, context) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }
@@ -115,17 +116,21 @@ export default function(expectation, options, context) {
       if (context.fix && !isFixDisabled) {
         if (expectHasEmptyLineBefore && !hasEmptyLine(before)) {
           fix(decl, context.newline, context.newline + context.newline);
+
           if (
             optionsHaveException(options, "first-nested") &&
             !hasNewline(before)
           ) {
             fix(decl, "\\s+", context.newline + context.newline);
           }
+
           return;
         }
+
         if (!expectHasEmptyLineBefore && hasEmptyLine(before)) {
           fix(decl, "\\n\\r\\n", "\r\n");
           fix(decl, context.newline + context.newline, context.newline);
+
           return;
         }
       }

--- a/src/rules/dollar-variable-no-missing-interpolation/index.js
+++ b/src/rules/dollar-variable-no-missing-interpolation/index.js
@@ -54,6 +54,7 @@ function toRegex(arr) {
 export default function(actual) {
   return function(root, result) {
     const validOptions = utils.validateOptions(result, ruleName, { actual });
+
     if (!validOptions) {
       return;
     }
@@ -88,9 +89,11 @@ export default function(actual) {
       if (isAtSupports(node) || isCustomIdentProp(node)) {
         return includes(stringVars, value);
       }
+
       if (isCustomIdentAtRule(node)) {
         return includes(vars, value);
       }
+
       return false;
     }
 
@@ -113,9 +116,11 @@ export default function(actual) {
     function walkValues(node, value) {
       valueParser(value).walk(valNode => {
         const { value } = valNode;
+
         if (exitEarly(valNode) || !shouldReport(node, value)) {
           return;
         }
+
         report(node, value);
       });
     }

--- a/src/rules/dollar-variable-pattern/index.js
+++ b/src/rules/dollar-variable-pattern/index.js
@@ -25,6 +25,7 @@ export default function(pattern, options) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }
@@ -37,6 +38,7 @@ export default function(pattern, options) {
       if (prop[0] !== "$") {
         return;
       }
+
       // If local or global variables need to be ignored
       if (
         (optionsHaveIgnored(options, "global") &&
@@ -45,6 +47,7 @@ export default function(pattern, options) {
       ) {
         return;
       }
+
       if (regexpPattern.test(prop.slice(1))) {
         return;
       }

--- a/src/rules/double-slash-comment-empty-line-before/index.js
+++ b/src/rules/double-slash-comment-empty-line-before/index.js
@@ -33,6 +33,7 @@ export default function(expectation, options, context) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }
@@ -41,6 +42,7 @@ export default function(expectation, options, context) {
       const escapedMatch = match.replace(/(\r)?\n/g, (_, r) =>
         r ? "\\r\\n" : "\\n"
       );
+
       comment.raws.before = comment.raws.before.replace(
         new RegExp(`^${escapedMatch}`),
         replace
@@ -72,6 +74,7 @@ export default function(expectation, options, context) {
 
       // Optionally ignore newlines between comments
       const prev = comment.prev();
+
       if (
         prev &&
         prev.type === "comment" &&
@@ -90,6 +93,7 @@ export default function(expectation, options, context) {
         ) {
           return false;
         }
+
         return expectation === "always";
       })();
 
@@ -103,10 +107,13 @@ export default function(expectation, options, context) {
       if (context.fix) {
         if (expectEmptyLineBefore && !hasEmptyLineBefore) {
           fix(comment, context.newline, context.newline + context.newline);
+
           return;
         }
+
         if (!expectEmptyLineBefore && hasEmptyLineBefore) {
           fix(comment, context.newline + context.newline, context.newline);
+
           return;
         }
       }

--- a/src/rules/double-slash-comment-inline/index.js
+++ b/src/rules/double-slash-comment-inline/index.js
@@ -32,6 +32,7 @@ export default function(expectation, options) {
         optional: true
       }
     );
+
     if (!validOptions) {
       return;
     }
@@ -40,10 +41,13 @@ export default function(expectation, options) {
 
     function checkRoot(root) {
       const rootString = root.source.input.css;
+
       if (rootString.trim() === "") {
         return;
       }
+
       const comments = findCommentsInRaws(rootString);
+
       comments.forEach(comment => {
         // Only process // comments
         if (comment.type !== "double-slash") {

--- a/src/rules/double-slash-comment-whitespace-inside/__tests__/index.js
+++ b/src/rules/double-slash-comment-whitespace-inside/__tests__/index.js
@@ -1,4 +1,4 @@
-import rule, { ruleName, messages } from "..";
+import rule, { messages, ruleName } from "..";
 
 // -------------------------------------------------------------------------
 // "always"
@@ -189,7 +189,7 @@ testRule(rule, {
 
       /// 3-slash comment with space
     `,
-      /* eslint-disable no-multiple-empty-lines */
+      /* eslint-enable no-multiple-empty-lines */
       description: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space.",
       message: messages.rejected,
       line: 5,

--- a/src/rules/double-slash-comment-whitespace-inside/index.js
+++ b/src/rules/double-slash-comment-whitespace-inside/index.js
@@ -14,6 +14,7 @@ export default function(expectation) {
       actual: expectation,
       possible: ["always", "never"]
     });
+
     if (!validOptions) {
       return;
     }
@@ -22,15 +23,19 @@ export default function(expectation) {
 
     function checkRoot(root) {
       const rootString = root.source.input.css;
+
       if (rootString.trim() === "") {
         return;
       }
+
       const comments = findCommentsInRaws(rootString);
+
       comments.forEach(comment => {
         // Only process // comments
         if (comment.type !== "double-slash") {
           return;
         }
+
         // if it's `//` - no warning whatsoever; if `// ` - then trailing
         // whitespace rule will govern this
         if (comment.text === "") {

--- a/src/rules/media-feature-value-dollar-variable/index.js
+++ b/src/rules/media-feature-value-dollar-variable/index.js
@@ -15,6 +15,7 @@ export default function(expectation) {
       actual: expectation,
       possible: ["always", "never"]
     });
+
     if (!validOptions) {
       return;
     }
@@ -31,10 +32,12 @@ export default function(expectation) {
 
     root.walkAtRules("media", atRule => {
       const found = atRule.params.match(valueRegexGlobal);
+
       // If there are no values
       if (!found || !found.length) {
         return;
       }
+
       found.forEach(function(found) {
         // ... parse `: 10px )` to `10px`
         const valueParsed = found.match(valueRegex)[1];

--- a/src/rules/operator-no-newline-after/index.js
+++ b/src/rules/operator-no-newline-after/index.js
@@ -24,11 +24,13 @@ function checkNewlineBefore({
   let newLineBefore = false;
 
   let index = endIndex + 1;
+
   while (index && isWhitespace(string[index])) {
     if (string[index] === "\n") {
       newLineBefore = true;
       break;
     }
+
     index++;
   }
 
@@ -48,6 +50,7 @@ export default function(expectation) {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation
     });
+
     if (!validOptions) {
       return;
     }

--- a/src/rules/operator-no-newline-before/index.js
+++ b/src/rules/operator-no-newline-before/index.js
@@ -24,11 +24,13 @@ function checkNewlineBefore({
   let newLineBefore = false;
 
   let index = startIndex - 1;
+
   while (index && isWhitespace(string[index])) {
     if (string[index] === "\n") {
       newLineBefore = true;
       break;
     }
+
     index--;
   }
 
@@ -48,6 +50,7 @@ export default function(expectation) {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation
     });
+
     if (!validOptions) {
       return;
     }

--- a/src/rules/operator-no-unspaced/__tests__/index.js
+++ b/src/rules/operator-no-unspaced/__tests__/index.js
@@ -1609,7 +1609,8 @@ test("+ without whitespaces: `#{$var}+#ffc`.", () => {
     .process("a { width: #{$var}+#ffc; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expectedBefore("+"));
       expect(warnings[0].column).toBe(19);
       expect(warnings[1].text).toBe(messages.expectedAfter("+"));
@@ -1624,7 +1625,8 @@ test("+ without whitespaces: `1+1s`.", () => {
     .process("a { width: 1+1s; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expectedBefore("+"));
       expect(warnings[0].column).toBe(13);
       expect(warnings[1].text).toBe(messages.expectedAfter("+"));
@@ -1639,7 +1641,8 @@ test("- without whitespaces: `5px-3px`.", () => {
     .process("a { width: 5px-3px; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expectedBefore("-"));
       expect(warnings[0].column).toBe(15);
       expect(warnings[1].text).toBe(messages.expectedAfter("-"));
@@ -1654,7 +1657,8 @@ test("- without whitespaces: `.1px-1px`.", () => {
     .process("a { width: .1px-1px; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expectedBefore("-"));
       expect(warnings[0].column).toBe(16);
       expect(warnings[1].text).toBe(messages.expectedAfter("-"));
@@ -1669,7 +1673,8 @@ test("- without whitespaces: `s.1px-1`.", () => {
     .process("a { width: s.1px-1; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expectedBefore("-"));
       expect(warnings[0].column).toBe(17);
       expect(warnings[1].text).toBe(messages.expectedAfter("-"));
@@ -1684,7 +1689,8 @@ test("fn()-1", () => {
     .process("a { width: fn()-1; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expectedBefore("-"));
       expect(warnings[0].column).toBe(16);
       expect(warnings[1].text).toBe(messages.expectedAfter("-"));
@@ -1699,7 +1705,8 @@ test("fn()/1", () => {
     .process("a { width: fn()/1; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expectedBefore("/"));
       expect(warnings[0].column).toBe(16);
       expect(warnings[1].text).toBe(messages.expectedAfter("/"));
@@ -1716,7 +1723,8 @@ test("$var==1", () => {
     .process("a { width: $var==1; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expectedBefore("=="));
       expect(warnings[0].column).toBe(16);
       expect(warnings[1].text).toBe(messages.expectedAfter("=="));
@@ -1731,7 +1739,8 @@ test("var==var", () => {
     .process("a { width: var==var; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expectedBefore("=="));
       expect(warnings[0].column).toBe(15);
       expect(warnings[1].text).toBe(messages.expectedAfter("=="));
@@ -1748,7 +1757,8 @@ test("8px/2px +$var`.", () => {
     .process("a { width: 8px/2px +$var; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
     })
     .catch(logError);
 });
@@ -1759,7 +1769,8 @@ test("#{$var}+8px/2px (+ is not math op, so isn't /. But + is concatenation, so 
     .process("a { width: #{$var}+8px/2px; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       expect(warnings[0].text).toBe(messages.expectedBefore("+"));
       expect(warnings[0].column).toBe(19);
       expect(warnings[1].text).toBe(messages.expectedAfter("+"));
@@ -1773,7 +1784,8 @@ test("8px/2px+ $var`.", () => {
     .process("a { width: 8px/2px+ $var; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
     })
     .catch(logError);
 });
@@ -1783,7 +1795,8 @@ test("8px/2px +fn()`.", () => {
     .process("a { width: 8px/2px +fn(); }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
     })
     .catch(logError);
 });
@@ -1793,7 +1806,8 @@ test("8px/2px+ fn()`.", () => {
     .process("a { width: 8px/2px+ fn(); }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
     })
     .catch(logError);
 });
@@ -1803,7 +1817,8 @@ test("8px/2px+ 5px`.", () => {
     .process("a { width: 8px/2px+ 5px; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
     })
     .catch(logError);
 });
@@ -1813,7 +1828,8 @@ test("8px/2px+ 5`.", () => {
     .process("a { width: 8px/2px+ 5; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
     })
     .catch(logError);
 });
@@ -1824,7 +1840,8 @@ test("8px/2px -$var`.", () => {
     .process("a { width: 8px/2px -$var; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
     })
     .catch(logError);
 });
@@ -1834,7 +1851,8 @@ test("8px/2-$var`.", () => {
     .process("a { width: 8px/2-$var; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(4);
+
+      expect(warnings).toHaveLength(4);
     })
     .catch(logError);
 });
@@ -1844,7 +1862,8 @@ test("8px/2- $var`.", () => {
     .process("a { width: 8px/2- $var; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
     })
     .catch(logError);
 });
@@ -1854,7 +1873,8 @@ test("8px/2- 5px`.", () => {
     .process("a { width: 8px/2- 5px; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(3);
+
+      expect(warnings).toHaveLength(3);
     })
     .catch(logError);
 });
@@ -1864,7 +1884,8 @@ test("8px/2px-5px`.", () => {
     .process("a { width: 8px/2px-5px; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(4);
+
+      expect(warnings).toHaveLength(4);
     })
     .catch(logError);
 });
@@ -1874,7 +1895,8 @@ test("8px/2-5px`.", () => {
     .process("a { width: 8px/2-5px; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(4);
+
+      expect(warnings).toHaveLength(4);
     })
     .catch(logError);
 });
@@ -1884,7 +1906,8 @@ test("8px/2px-5`.", () => {
     .process("a { width: 8px/2px-5; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(4);
+
+      expect(warnings).toHaveLength(4);
     })
     .catch(logError);
 });
@@ -1894,7 +1917,8 @@ test("8px/2-5`.", () => {
     .process("a { width: 8px/2-5; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(4);
+
+      expect(warnings).toHaveLength(4);
     })
     .catch(logError);
 });
@@ -1907,7 +1931,8 @@ test("5+8px/2`.", () => {
     .process("a { width: 5+8px/2; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(4);
+
+      expect(warnings).toHaveLength(4);
     })
     .catch(logError);
 });
@@ -1917,7 +1942,8 @@ test("5px*8px/2`.", () => {
     .process("a { width: 5px*8px/2; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(4);
+
+      expect(warnings).toHaveLength(4);
     })
     .catch(logError);
 });
@@ -1927,7 +1953,8 @@ test("5px - 8px/2`.", () => {
     .process("a { width: 5px - 8px/2; }", { syntax: scss, from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
     })
     .catch(logError);
 });

--- a/src/rules/operator-no-unspaced/index.js
+++ b/src/rules/operator-no-unspaced/index.js
@@ -33,6 +33,7 @@ function checkSpaces({
   const beforeOk =
     (string[startIndex - 1] === " " && !isWhitespace(string[startIndex - 2])) ||
     newlineBefore(string, startIndex - 1);
+
   if (!beforeOk) {
     utils.report({
       ruleName,
@@ -61,10 +62,13 @@ function checkSpaces({
 
 function newlineBefore(str, startIndex) {
   let index = startIndex;
+
   while (index && isWhitespace(str[index])) {
     if (str[index] === "\n") return true;
+
     index--;
   }
+
   return false;
 }
 
@@ -73,6 +77,7 @@ export default function(expectation) {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation
     });
+
     if (!validOptions) {
       return;
     }
@@ -81,9 +86,11 @@ export default function(expectation) {
 
     function checkRoot(root) {
       const rootString = root.source.input.css;
+
       if (rootString.trim() === "") {
         return;
       }
+
       calculationOperatorSpaceChecker({
         root,
         result,
@@ -124,6 +131,7 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
     const results = [];
     // Searching for interpolation
     let match = interpolationRegex.exec(string);
+
     startIndex = !isNaN(startIndex) ? Number(startIndex) : 0;
     while (match !== null) {
       results.push({
@@ -135,6 +143,7 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
       });
       match = interpolationRegex.exec(string);
     }
+
     return results;
   }
 
@@ -162,6 +171,7 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
     if (item.prop !== undefined) {
       results = results.concat(findInterpolation(item.prop));
     }
+
     // Selector
     if (item.selector !== undefined) {
       results = results.concat(findInterpolation(item.selector));
@@ -172,6 +182,7 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
       if (item.name === "media" || item.name === "import") {
         mediaQueryParser(item.params).walk(node => {
           const type = node.type;
+
           if (["keyword", "media-type", "media-feature"].indexOf(type) !== -1) {
             results = results.concat(
               findInterpolation(
@@ -228,6 +239,7 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
       comment.source.start +
       comment.raws.startToken.length +
       comment.raws.left.length;
+
     if (comment.type !== "css") {
       return;
     }

--- a/src/rules/partial-no-import/__tests__/index.js
+++ b/src/rules/partial-no-import/__tests__/index.js
@@ -13,7 +13,8 @@ test("No file specified", done => {
     .process("@import 'file.scss';", { from: undefined })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
       expect(warnings[0].text).toBe(
         "The 'partial-no-import' rule won't work if linting in a code string without an actual file."
       );
@@ -30,7 +31,8 @@ test("Import a file from non-partial .scss", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
       done();
     });
 });
@@ -43,12 +45,13 @@ test("Import a file from a partial .scss", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
       done();
     });
 });
 
-test("Import a file from a partial .scss", done => {
+test("Import a file from a partial .scss 2", done => {
   expect.assertions(1);
   postcss([rule()])
     .process('@import "file.scss";', {
@@ -56,7 +59,8 @@ test("Import a file from a partial .scss", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
       done();
     });
 });
@@ -69,12 +73,13 @@ test("Ignores empty imports (Sass will throw an error instead)", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
       done();
     });
 });
 
-test("Ignores empty imports (Sass will throw an error instead)", done => {
+test("Ignores empty imports (Sass will throw an error instead) 2", done => {
   expect.assertions(1);
   postcss([rule()])
     .process('@import " ";', {
@@ -82,7 +87,8 @@ test("Ignores empty imports (Sass will throw an error instead)", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
       done();
     });
 });
@@ -95,7 +101,8 @@ test("Import a file from a partial .scss; omitting extension", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
       done();
     });
 });
@@ -108,12 +115,13 @@ test("Import comma separated files from a partial .scss; omitting extension", do
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       done();
     });
 });
 
-test("Import comma separated files from a partial .scss; omitting extension", done => {
+test("Import comma separated files from a partial .scss; omitting extension 2", done => {
   expect.assertions(1);
   postcss([rule()])
     .process('@import "file" , "file2";', {
@@ -121,7 +129,8 @@ test("Import comma separated files from a partial .scss; omitting extension", do
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       done();
     });
 });
@@ -135,7 +144,8 @@ test("Import a file from CSS", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
       done();
     });
 });
@@ -148,7 +158,8 @@ test("Import a CSS from a partial .scss", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
       done();
     });
 });
@@ -161,7 +172,8 @@ test("Import a CSS (url) from a partial .scss", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
       done();
     });
 });
@@ -174,7 +186,8 @@ test("Import a CSS (with protocol) from a partial .scss", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
       done();
     });
 });
@@ -190,7 +203,8 @@ test("Import a CSS file (font URL with https) from a partial .scss", done => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
       done();
     });
 });
@@ -206,12 +220,13 @@ test("Import a local file and a CSS file (font URL with https) from a partial .s
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
       done();
     });
 });
 
-test("Import a local file and a CSS file (font URL with https) from a partial .scss (warn for local file, but not https import)", done => {
+test("Import a local file and a CSS file (font URL with https) from a partial .scss (warn for local file, but not https import) 2", done => {
   expect.assertions(1);
   postcss([rule()])
     .process(
@@ -222,12 +237,13 @@ test("Import a local file and a CSS file (font URL with https) from a partial .s
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
       done();
     });
 });
 
-test("Import a local file and a CSS file (font URL with https) from a partial .scss (warn for local file, but not https import)", done => {
+test("Import a local file and a CSS file (font URL with https) from a partial .scss (warn for local file, but not https import) 3", done => {
   expect.assertions(1);
   postcss([rule()])
     .process(
@@ -238,7 +254,8 @@ test("Import a local file and a CSS file (font URL with https) from a partial .s
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+
+      expect(warnings).toHaveLength(1);
       done();
     });
 });
@@ -251,7 +268,8 @@ test("Import a CSS (with media) from a partial .scss", done => {
     })
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
       done();
     });
 });
@@ -267,7 +285,8 @@ test("Multiple imports in a partial.", done => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(2);
+
+      expect(warnings).toHaveLength(2);
       done();
     });
 });
@@ -283,7 +302,8 @@ test("Import from a non-partial SCSS-file.", done => {
     )
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(0);
+
+      expect(warnings).toHaveLength(0);
       done();
     });
 });

--- a/src/rules/partial-no-import/index.js
+++ b/src/rules/partial-no-import/index.js
@@ -13,6 +13,7 @@ export default function(on) {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: on
     });
+
     if (!validOptions) {
       return;
     }
@@ -21,6 +22,7 @@ export default function(on) {
       result.warn(
         "The 'partial-no-import' rule won't work if linting in a code string without an actual file."
       );
+
       return;
     }
 
@@ -57,6 +59,7 @@ export default function(on) {
     if (extName === ".css") {
       return;
     }
+
     // Not a partial
     if (fileName[0] !== "_") {
       return;

--- a/src/rules/percent-placeholder-pattern/index.js
+++ b/src/rules/percent-placeholder-pattern/index.js
@@ -22,6 +22,7 @@ export default function(pattern) {
       actual: pattern,
       possible: [isRegExp, isString]
     });
+
     if (!validOptions) {
       return;
     }
@@ -33,6 +34,7 @@ export default function(pattern) {
     // Checking placeholder definitions (looking among regular rules)
     root.walkRules(rule => {
       const { selector } = rule;
+
       // Just a shorthand for calling `parseSelector`
       function parse(selector) {
         parseSelector(selector, result, rule, s => checkSelector(s, rule));
@@ -42,6 +44,7 @@ export default function(pattern) {
       if (!isStandardRule(rule)) {
         return;
       }
+
       // If the selector has interpolation
       if (!isStandardSelector(selector)) {
         return;
@@ -63,14 +66,17 @@ export default function(pattern) {
       // postcss-selector-parser gives %placeholders' nodes a "tag" type
       fullSelector.walkTags(compoundSelector => {
         const { value, sourceIndex } = compoundSelector;
+
         if (value[0] !== "%") {
           return;
         }
+
         const placeholder = value.slice(1);
 
         if (placeholderPattern.test(placeholder)) {
           return;
         }
+
         utils.report({
           result,
           ruleName,

--- a/src/rules/selector-no-redundant-nesting-selector/index.js
+++ b/src/rules/selector-no-redundant-nesting-selector/index.js
@@ -10,6 +10,7 @@ export const messages = utils.ruleMessages(ruleName, {
 export default function(actual) {
   return function(root, result) {
     const validOptions = utils.validateOptions(result, ruleName, { actual });
+
     if (!validOptions) {
       return;
     }

--- a/src/utils/__tests__/findCommentsInRaws.js
+++ b/src/utils/__tests__/findCommentsInRaws.js
@@ -15,7 +15,7 @@ test("// is the first statement in the file", () => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
-      expect(comments.length).toBe(1);
+      expect(comments).toHaveLength(1);
       expect(comments[0].text).toBe("comment");
       expect(comments[0].inlineAfter).toBe(false);
       expect(comments[0].inlineBefore).toBe(false);
@@ -37,7 +37,7 @@ test("// is the first statement in a string, w/o pre-whs", () => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
-      expect(comments.length).toBe(1);
+      expect(comments).toHaveLength(1);
       expect(comments[0].text).toBe("comment");
       expect(comments[0].inlineAfter).toBe(false);
       expect(comments[0].inlineBefore).toBe(false);
@@ -55,7 +55,7 @@ test("CSS-comment is the first statement (and the last one) in a file", () => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
-      expect(comments.length).toBe(1);
+      expect(comments).toHaveLength(1);
       expect(comments[0].text).toBe("comment1");
       expect(comments[0].inlineAfter).toBe(false);
       expect(comments[0].inlineBefore).toBe(false);
@@ -78,7 +78,7 @@ test("CSS-comment is the first statement (and the last one) in a string", () => 
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
-      expect(comments.length).toBe(1);
+      expect(comments).toHaveLength(1);
       expect(comments[0].text).toBe("comment1");
       expect(comments[0].inlineAfter).toBe(false);
       expect(comments[0].inlineBefore).toBe(false);
@@ -114,7 +114,7 @@ test("Various.", () => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
-      expect(comments.length).toBe(3);
+      expect(comments).toHaveLength(3);
       expect(comments[0].text).toBe("comment");
       expect(comments[0].raws.startToken).toBe("/**!");
       expect(comments[0].raws.endToken).toBe("*/");
@@ -147,7 +147,7 @@ test("//", () => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
-      expect(comments.length).toBe(1);
+      expect(comments).toHaveLength(1);
       expect(comments[0].text).toBe("");
       expect(comments[0].inlineAfter).toBe(false);
       expect(comments[0].source).toEqual({ start: 7, end: 8 });
@@ -171,7 +171,7 @@ test("// Inline comment, after {.", () => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
-      expect(comments.length).toBe(1);
+      expect(comments).toHaveLength(1);
       expect(comments[0].text).toBe("Inline comment, after {.");
       expect(comments[0].inlineAfter).toBe(true);
     })
@@ -191,7 +191,8 @@ test("} // comment", () => {
     .then(result => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
-      expect(comments.length).toBe(1);
+
+      expect(comments).toHaveLength(1);
       expect(comments[0].inlineAfter).toBe(true);
     })
     .catch(logError);
@@ -205,7 +206,8 @@ test("Triple-slash comment", () => {
     .then(result => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
-      expect(comments.length).toBe(1);
+
+      expect(comments).toHaveLength(1);
       expect(comments[0].text).toBe("comment");
       expect(comments[0].raws.startToken).toBe("///");
       expect(comments[0].inlineAfter).toBe(true);
@@ -230,7 +232,8 @@ test("Some fancy comment", () => {
     .then(result => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
-      expect(comments.length).toBe(1);
+
+      expect(comments).toHaveLength(1);
       expect(comments[0].raws.startToken).toBe("/*!");
       expect(comments[0].inlineAfter).toBe(false);
       expect(comments[0].raws.left).toBe(
@@ -257,7 +260,8 @@ test("Another fancy comment", () => {
     .then(result => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
-      expect(comments.length).toBe(1);
+
+      expect(comments).toHaveLength(1);
       expect(comments[0].raws.startToken).toBe("/*");
       expect(comments[0].inlineAfter).toBe(false);
       expect(comments[0].raws.left).toBe(" ");
@@ -283,7 +287,8 @@ test("Comments inside comments", () => {
     .then(result => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
-      expect(comments.length).toBe(3);
+
+      expect(comments).toHaveLength(3);
       expect(comments[0].text).toBe("Text.. /* is that a new comment?");
       expect(comments[0].source).toEqual({ start: 7, end: 44 });
       expect(comments[1].text).toBe("And /* this */ ?");
@@ -313,7 +318,8 @@ test("No comments, but parsing a selector with ().", () => {
     .then(result => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
-      expect(comments.length).toBe(0);
+
+      expect(comments).toHaveLength(0);
     })
     .catch(logError);
 });
@@ -326,7 +332,8 @@ test("//-comment, Unix newlines", () => {
     .then(result => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
-      expect(comments.length).toBe(1);
+
+      expect(comments).toHaveLength(1);
       expect(comments[0].source).toEqual({ start: 4, end: 14 });
     })
     .catch(logError);
@@ -340,7 +347,8 @@ test("CSS comment, Unix newlines", () => {
     .then(result => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
-      expect(comments.length).toBe(1);
+
+      expect(comments).toHaveLength(1);
       expect(comments[0].source).toEqual({ start: 4, end: 23 });
     })
     .catch(logError);
@@ -354,7 +362,8 @@ test("//-comment, Windows-newline", () => {
     .then(result => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
-      expect(comments.length).toBe(1);
+
+      expect(comments).toHaveLength(1);
       expect(comments[0].source).toEqual({ start: 5, end: 15 });
     })
     .catch(logError);
@@ -371,7 +380,8 @@ test("CSS comment, Windows newlines", () => {
     .then(result => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
-      expect(comments.length).toBe(1);
+
+      expect(comments).toHaveLength(1);
       expect(comments[0].source).toEqual({ start: 5, end: 25 });
     })
     .catch(logError);
@@ -386,7 +396,7 @@ test("No comments; testing a dangerous case in function detection [`@media( ... 
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
-      expect(comments.length).toBe(0);
+      expect(comments).toHaveLength(0);
     })
     .catch(logError);
 });

--- a/src/utils/__tests__/isInlineComment.js
+++ b/src/utils/__tests__/isInlineComment.js
@@ -117,10 +117,11 @@ test("Inline comment, after a selector (in a list). IGNORED.", () => {
     )
     .then(result => {
       let res = null;
+
       result.root.walkComments(comment => {
         res = isInlineComment(comment);
       });
-      expect(res).toBe(null);
+      expect(res).toBeNull();
     })
     .catch(logError);
 });
@@ -140,10 +141,11 @@ test("Inline comment, after a selector, comment prior. IGNORED.", () => {
     )
     .then(result => {
       let res = null;
+
       result.root.walkComments(comment => {
         res = isInlineComment(comment);
       });
-      expect(res).toBe(null);
+      expect(res).toBeNull();
     })
     .catch(logError);
 });

--- a/src/utils/__tests__/parseFunctionArguments.js
+++ b/src/utils/__tests__/parseFunctionArguments.js
@@ -262,7 +262,7 @@ describe("parseFunctionArguments", () => {
     ]);
   });
 
-  it("parses 2 key value parameters", () => {
+  it("parses 2 key value parameters 2", () => {
     expect(
       parseFunctionArguments(
         "reset($value: 40px, $second-value: 10px, $color: 'black')"

--- a/src/utils/__tests__/parseNestedPropRoot.js
+++ b/src/utils/__tests__/parseNestedPropRoot.js
@@ -160,7 +160,7 @@ test("`background:red` (compiles to a selector by Sass)", () => {
 
   const result = parseNestedPropRoot("background:red");
 
-  expect(result).toBe(null);
+  expect(result).toBeNull();
 });
 
 test("`background :red` (compiles to a selector by Sass)", () => {
@@ -168,7 +168,7 @@ test("`background :red` (compiles to a selector by Sass)", () => {
 
   const result = parseNestedPropRoot("background :red");
 
-  expect(result).toBe(null);
+  expect(result).toBeNull();
 });
 
 test("`&:a1px` (trying to invoke false positive for a number as a value)", () => {
@@ -176,7 +176,7 @@ test("`&:a1px` (trying to invoke false positive for a number as a value)", () =>
 
   const result = parseNestedPropRoot("&:a1px");
 
-  expect(result).toBe(null);
+  expect(result).toBeNull();
 });
 
 test("`input:-moz-focusring `", () => {
@@ -184,7 +184,7 @@ test("`input:-moz-focusring `", () => {
 
   const result = parseNestedPropRoot("input:-moz-focusring");
 
-  expect(result).toEqual(null);
+  expect(result).toBeNull();
 });
 
 test("`&:not(.other-class) `", () => {
@@ -192,7 +192,7 @@ test("`&:not(.other-class) `", () => {
 
   const result = parseNestedPropRoot("&:not(.other-class)");
 
-  expect(result).toEqual(null);
+  expect(result).toBeNull();
 });
 
 test("`&:pseudo`", () => {
@@ -200,7 +200,7 @@ test("`&:pseudo`", () => {
 
   const result = parseNestedPropRoot("&:pseudo");
 
-  expect(result).toEqual(null);
+  expect(result).toBeNull();
 });
 
 // --------------------------------------------------------------------------
@@ -212,7 +212,7 @@ test('`"input: prop"` (a "-string)', () => {
 
   const result = parseNestedPropRoot('"input: prop"');
 
-  expect(result).toEqual(null);
+  expect(result).toBeNull();
 });
 
 test("`'input: prop'` (a '-string)", () => {
@@ -220,5 +220,5 @@ test("`'input: prop'` (a '-string)", () => {
 
   const result = parseNestedPropRoot("'input: prop'");
 
-  expect(result).toEqual(null);
+  expect(result).toBeNull();
 });

--- a/src/utils/atRuleParamIndex.js
+++ b/src/utils/atRuleParamIndex.js
@@ -7,8 +7,10 @@
 export default function(atRule) {
   // Initial 1 is for the `@`
   let index = 1 + atRule.name.length;
+
   if (atRule.raw("afterName")) {
     index += atRule.raw("afterName").length;
   }
+
   return index;
 }

--- a/src/utils/beforeBlockString.js
+++ b/src/utils/beforeBlockString.js
@@ -12,6 +12,7 @@
  */
 export default function(statement, { noRawBefore } = {}) {
   let result = "";
+
   if (statement.type !== "rule" && statement.type !== "atrule") {
     return result;
   }
@@ -19,6 +20,7 @@ export default function(statement, { noRawBefore } = {}) {
   if (!noRawBefore) {
     result += statement.raws.before;
   }
+
   if (statement.type === "rule") {
     result += statement.selector;
   } else {

--- a/src/utils/blockString.js
+++ b/src/utils/blockString.js
@@ -15,5 +15,6 @@ export default function(statement) {
   if (!hasBlock(statement)) {
     return;
   }
+
   return rawNodeString(statement).slice(beforeBlockString(statement).length);
 }

--- a/src/utils/configurationError.js
+++ b/src/utils/configurationError.js
@@ -6,6 +6,8 @@
  */
 export default function(text) {
   const err = new Error(text);
+
   err.code = 78;
+
   return err;
 }

--- a/src/utils/declarationValueIndex.js
+++ b/src/utils/declarationValueIndex.js
@@ -8,5 +8,6 @@ export default function(decl) {
   const beforeColon = decl.toString().indexOf(":");
   const afterColon =
     decl.raw("between").length - decl.raw("between").indexOf(":");
+
   return beforeColon + afterColon;
 }

--- a/src/utils/findCommentsInRaws.js
+++ b/src/utils/findCommentsInRaws.js
@@ -60,6 +60,7 @@ export default function findCommentsInRaws(rawString) {
         if (mode === "comment") {
           break;
         }
+
         if (
           mode === "string" &&
           modesEntered[lastModeIndex].character === character &&
@@ -74,6 +75,7 @@ export default function findCommentsInRaws(rawString) {
             character
           });
         }
+
         break;
       }
       // Entering url, other function or parens (only url matters)
@@ -81,9 +83,11 @@ export default function findCommentsInRaws(rawString) {
         if (mode === "comment" || mode === "string") {
           break;
         }
+
         const functionNameRegSearch = /(?:^|(?:\n)|(?:\r)|(?:\s-)|[:\s,.(){}*+/%])([a-zA-Z0-9_-]*)$/.exec(
           rawString.substring(0, i)
         );
+
         // A `\S(` can be in, say, `@media(`
         if (!functionNameRegSearch) {
           modesEntered.push({
@@ -94,6 +98,7 @@ export default function findCommentsInRaws(rawString) {
         }
 
         const functionName = functionNameRegSearch[1];
+
         modesEntered.push({
           mode: functionName === "url" ? "url" : "parens",
           character: "("
@@ -105,6 +110,7 @@ export default function findCommentsInRaws(rawString) {
         if (mode === "comment" || mode === "string") {
           break;
         }
+
         modesEntered.pop();
         break;
       }
@@ -116,6 +122,7 @@ export default function findCommentsInRaws(rawString) {
         if (mode === "comment" || mode === "string") {
           break;
         }
+
         if (nextChar === "*") {
           modesEntered.push({
             mode: "comment",
@@ -136,6 +143,7 @@ export default function findCommentsInRaws(rawString) {
           if (mode === "url") {
             break;
           }
+
           modesEntered.push({
             mode: "comment",
             character: "//"
@@ -151,6 +159,7 @@ export default function findCommentsInRaws(rawString) {
           // Skip the next iteration as the second slash in // is already checked
           i++;
         }
+
         break;
       }
       // Might be a closing `*/`
@@ -166,6 +175,7 @@ export default function findCommentsInRaws(rawString) {
           const matches = /^(\/\*+[!#]{0,1})(\s*)([\s\S]*?)(\s*?)(\*+\/)$/.exec(
             commentRaw
           );
+
           modesEntered.pop();
           comment.raws = {
             startToken: matches[1],
@@ -182,12 +192,14 @@ export default function findCommentsInRaws(rawString) {
           // Skip the next loop as the / in */ is already checked
           i++;
         }
+
         break;
       }
       default: {
         const isNewline =
           (character === "\r" && rawString[i + 1] === "\n") ||
           (character === "\n" && rawString[i - 1] !== "\r");
+
         // //-comments end before newline and if the code string ends
         if (isNewline || i === rawString.length - 1) {
           if (
@@ -217,6 +229,7 @@ export default function findCommentsInRaws(rawString) {
             offset += 2;
           }
         }
+
         break;
       }
     }

--- a/src/utils/hasInterpolatingAmpersand.js
+++ b/src/utils/hasInterpolatingAmpersand.js
@@ -14,13 +14,16 @@ export default function(selector) {
     if (selector[i] !== "&") {
       continue;
     }
+
     if (!_.isUndefined(selector[i - 1]) && !isCombinator(selector[i - 1])) {
       return true;
     }
+
     if (!_.isUndefined(selector[i + 1]) && !isCombinator(selector[i + 1])) {
       return true;
     }
   }
+
   return false;
 }
 

--- a/src/utils/parseFunctionArguments.js
+++ b/src/utils/parseFunctionArguments.js
@@ -19,10 +19,13 @@ export function groupByKeyValue(nodes) {
     if (isComma) {
       groupIndex++;
     }
+
     acc[groupIndex] = acc[groupIndex] || [];
+
     if (!isComma) {
       acc[groupIndex].push(node);
     }
+
     return acc;
   }, []);
 }
@@ -32,21 +35,27 @@ export function mapToKeyValue(nodes) {
     if (acc.length === 1) {
       return acc;
     }
+
     const nextNode = nodes[i + 1];
     const isNextNodeColon =
       nextNode && nextNode.type === "div" && nextNode.value === ":";
+
     if (isNextNodeColon) {
       acc.push({
         key: valueParser.stringify(nodes[i]),
         value: valueParser.stringify(nodes.slice(2))
       });
+
       return acc;
     }
+
     acc.push({
       value: valueParser.stringify(nodes)
     });
+
     return acc;
   }, []);
+
   return head(keyVal);
 }
 

--- a/src/utils/parseNestedPropRoot.js
+++ b/src/utils/parseNestedPropRoot.js
@@ -64,6 +64,7 @@ export default function parseNestedPropRoot(propString) {
           before: /^(\s*)/.exec(propValueStr)[1],
           value: propValueStr.trim()
         };
+
         // It's a declaration if 1) there is a whitespace after :, or
         // 2) the value is a number with/without a unit (starts with a number
         // or a dot), or

--- a/src/utils/rawNodeString.js
+++ b/src/utils/rawNodeString.js
@@ -6,9 +6,12 @@
  */
 export default function(node) {
   let result = "";
+
   if (node.raws.before) {
     result += node.raws.before;
   }
+
   result += node.toString();
+
   return result;
 }

--- a/src/utils/sassValueParser/index.js
+++ b/src/utils/sassValueParser/index.js
@@ -96,6 +96,7 @@ export default function findOperators({
         startIndex: i,
         endIndex: i
       });
+
       if (callback) {
         callback(string, globalIndex, i, i);
       }
@@ -109,11 +110,13 @@ export default function findOperators({
         startIndex: i,
         endIndex: i + 1
       });
+
       if (callback) {
         callback(string, globalIndex, i, i + 1);
       }
     }
   }
+
   // result.length > 0 && console.log(string, result)
   return result;
 }
@@ -219,9 +222,11 @@ function checkPlus(string, index, isAftercolon) {
       // console.log('1+1')
       return "sign";
     }
+
     // console.log("+, no spaces")
     return "op";
   }
+
   // e.g. `something +something`
   if (!isAtEnd_ && !isWhitespaceAfter) {
     // e.g. `+something`, ` ... , +something`, etc.
@@ -271,6 +276,7 @@ function checkPlus(string, index, isAftercolon) {
         // console.log("+10px or +1, before is an operator")
         return "sign";
       }
+
       // console.log("+#000, +string, +#{sth}, +$var")
       return "op";
     }
@@ -381,6 +387,7 @@ function checkMinus(string, index) {
         // console.log("-, sign: -$var, another operator before")
         return "sign";
       }
+
       // console.log("-, op: -$var, NO other operator before")
       return "op";
     }
@@ -402,6 +409,7 @@ function checkMinus(string, index) {
       // console.log('`-, op: 10- <sth>, #aff- <sth>`')
       return "op";
     }
+
     // console.log('-, char: default in <sth>- <sth>')
     return "char";
   }
@@ -423,6 +431,7 @@ function checkMinus(string, index) {
 
       // The - could be a "sign" here, but for now "char" does the job
     }
+
     // `1-$var`
     if (isNumberBefore_ && after[0] === "$") {
       // console.log("-, op: 1-$var")
@@ -535,6 +544,7 @@ function checkSlash(string, index, isAfterColon) {
 
   // e.g. `(1px/1)`, `fn(7 / 15)`, but not `url(8/11)`
   const isInsideFn = isInsideFunctionCall(string, index);
+
   if (
     isInsideParens(string, index) ||
     (isInsideFn.is && isInsideFn.fn !== "url")
@@ -614,11 +624,13 @@ function checkPercent(string, index) {
 
 function isAtStart(string, index) {
   const before = string.substring(0, index).trim();
+
   return before.length === 0 || before.search(/[({,]$/) !== -1;
 }
 
 function isAtEnd(string, index) {
   const after = string.substring(index + 1).trim();
+
   return after.length === 0 || after.search(/^[,)}]/) !== -1;
 }
 
@@ -632,6 +644,7 @@ function isInsideParens(string, index) {
   ) {
     return true;
   }
+
   return false;
 }
 
@@ -641,6 +654,7 @@ function isInsideInterpolation(string, index) {
   if (before.search(/#\{[^}]*$/) !== -1) {
     return true;
   }
+
   return false;
 }
 
@@ -683,6 +697,7 @@ function isStringBefore(before) {
   if (stringOpsClipped !== before) {
     result.opsBetween = true;
   }
+
   // If it is quoted
   if (
     stringOpsClipped[stringOpsClipped.length - 1] === '"' ||
@@ -721,28 +736,34 @@ function isStringAfter(after) {
 function isInterpolationAfter(after) {
   const result = { is: false, opsBetween: false };
   const matches = after.match(/^\s*([+/*%-]\s*)*#{/);
+
   if (matches) {
     if (matches[0]) {
       result.is = true;
     }
+
     if (matches[1]) {
       result.opsBetween = true;
     }
   }
+
   return result;
 }
 
 function isParensAfter(after) {
   const result = { is: false, opsBetween: false };
   const matches = after.match(/^\s*([+/*%-]\s*)*\(/);
+
   if (matches) {
     if (matches[0]) {
       result.is = true;
     }
+
     if (matches[1]) {
       result.opsBetween = true;
     }
   }
+
   return result;
 }
 
@@ -763,12 +784,15 @@ function isInterpolationBefore(before) {
   const result = { is: false, opsBetween: false };
   // Removing preceding operators if any
   const beforeOpsClipped = before.replace(/(\s*[+/*%-])+$/, "");
+
   if (beforeOpsClipped !== before) {
     result.opsBetween = true;
   }
+
   if (beforeOpsClipped[beforeOpsClipped.length - 1] === "}") {
     result.is = true;
   }
+
   return result;
 }
 
@@ -791,14 +815,17 @@ function isValueWithUnitAfter(after) {
   const matches = after.match(
     /^\s*([+/*%-]\s*)*(\d+(\.\d+){0,1}|\.\d+)[a-zA-Z_0-9-]+(?:$|[)}, ])/
   );
+
   if (matches) {
     if (matches[0]) {
       result.is = true;
     }
+
     if (matches[1]) {
       result.opsBetween = true;
     }
   }
+
   return result;
 }
 
@@ -807,14 +834,17 @@ function isNumberAfter(after) {
   const matches = after.match(
     /^\s*([+/*%-]\s*)*(\d+(\.\d+){0,1}|\.\d+)(?:$|[)}, ])/
   );
+
   if (matches) {
     if (matches[0]) {
       result.is = true;
     }
+
     if (matches[1]) {
       result.opsBetween = true;
     }
   }
+
   return result;
 }
 
@@ -833,14 +863,17 @@ function isVariableBefore(before) {
 function isVariableAfter(after) {
   const result = { is: false, opsBetween: false };
   const matches = after.match(/^\s*([+/*%-]\s*)*\$/);
+
   if (matches) {
     if (matches[0]) {
       result.is = true;
     }
+
     if (matches[1]) {
       result.opsBetween = true;
     }
   }
+
   return result;
 }
 
@@ -855,14 +888,17 @@ function isFunctionAfter(after) {
   const matches = after.match(
     /^\s*(-\s+|[+/*%]\s*)*[a-zA_Z_-][a-zA-Z_0-9-]*\(/
   );
+
   if (matches) {
     if (matches[0]) {
       result.is = true;
     }
+
     if (matches[1]) {
       result.opsBetween = true;
     }
   }
+
   return result;
 }
 
@@ -878,6 +914,7 @@ function isHexColor(string) {
 
 function isHexColorAfter(after) {
   const afterTrimmed = after.match(/(.*?)(?:[)},+/*%-]|\s|$)/)[1].trim();
+
   return isHexColor(afterTrimmed);
 }
 
@@ -903,11 +940,13 @@ function isHexColorBefore(before) {
  */
 function isNoOperandBefore(string, index) {
   const before = string.substring(0, index).trim();
+
   return before.length === 0 || before.search(/[({,]&/) !== -1;
 }
 
 function isPrecedingOperator(string, index) {
   let prevCharIndex = -1;
+
   for (let i = index - 1; i >= 0; i--) {
     if (string[i].search(/\s/) === -1) {
       prevCharIndex = i;

--- a/src/utils/whitespaceChecker.js
+++ b/src/utils/whitespaceChecker.js
@@ -79,6 +79,7 @@ export default function(targetWhitespace, expectation, messages) {
       onlyOneChar,
       allowIndentation
     };
+
     switch (expectation) {
       case "always":
         expectBefore();
@@ -90,24 +91,28 @@ export default function(targetWhitespace, expectation, messages) {
         if (!isSingleLineString(lineCheckStr || source)) {
           return;
         }
+
         expectBefore(messages.expectedBeforeSingleLine);
         break;
       case "never-single-line":
         if (!isSingleLineString(lineCheckStr || source)) {
           return;
         }
+
         rejectBefore(messages.rejectedBeforeSingleLine);
         break;
       case "always-multi-line":
         if (isSingleLineString(lineCheckStr || source)) {
           return;
         }
+
         expectBefore(messages.expectedBeforeMultiLine);
         break;
       case "never-multi-line":
         if (isSingleLineString(lineCheckStr || source)) {
           return;
         }
+
         rejectBefore(messages.rejectedBeforeMultiLine);
         break;
       default:
@@ -130,6 +135,7 @@ export default function(targetWhitespace, expectation, messages) {
     onlyOneChar = false
   }) {
     activeArgs = { source, index, err, errTarget, onlyOneChar };
+
     switch (expectation) {
       case "always":
         expectAfter();
@@ -141,24 +147,28 @@ export default function(targetWhitespace, expectation, messages) {
         if (!isSingleLineString(lineCheckStr || source)) {
           return;
         }
+
         expectAfter(messages.expectedAfterSingleLine);
         break;
       case "never-single-line":
         if (!isSingleLineString(lineCheckStr || source)) {
           return;
         }
+
         rejectAfter(messages.rejectedAfterSingleLine);
         break;
       case "always-multi-line":
         if (isSingleLineString(lineCheckStr || source)) {
           return;
         }
+
         expectAfter(messages.expectedAfterMultiLine);
         break;
       case "never-multi-line":
         if (isSingleLineString(lineCheckStr || source)) {
           return;
         }
+
         rejectAfter(messages.rejectedAfterMultiLine);
         break;
       case "at-least-one-space":
@@ -176,6 +186,7 @@ export default function(targetWhitespace, expectation, messages) {
   function expectBefore(messageFunc = messages.expectedBefore) {
     if (activeArgs.allowIndentation) {
       expectBeforeAllowingIndentation(messageFunc);
+
       return;
     }
 
@@ -222,19 +233,23 @@ export default function(targetWhitespace, expectation, messages) {
       if (targetWhitespace === "newline") {
         return "\n";
       }
+
       if (targetWhitespace === "space") {
         return " ";
       }
     })();
     let i = index - 1;
+
     while (source[i] !== expectedChar) {
       if (source[i] === "\t" || source[i] === " ") {
         i--;
         continue;
       }
+
       err(
         messageFunc(activeArgs.errTarget ? activeArgs.errTarget : source[index])
       );
+
       return;
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1810,12 +1810,13 @@ escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.5.6"
 
-eslint-config-stylelint@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-stylelint/-/eslint-config-stylelint-9.0.0.tgz#46a154c9a57d3b0b64e37949b735e8098454a7c7"
+eslint-config-stylelint@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-stylelint/-/eslint-config-stylelint-10.0.0.tgz#33cff198f4c3ad1e9e75c0285945dd61800c59c5"
+  integrity sha512-hbE+gecvP+O3g+HaA7yoj7VPwKCbU2ySojSBytbkaY3+WvYsvk2VDPXBZ5K4x8agpDj0/6i7oJZ8oHaK055jUA==
   dependencies:
-    eslint-plugin-jest "^21.25.1"
-    eslint-plugin-node "^7.0.0"
+    eslint-plugin-jest "^22.0.0"
+    eslint-plugin-node "^8.0.0"
     eslint-plugin-sort-requires "^2.1.0"
 
 eslint-plugin-es@^1.3.1:
@@ -1825,9 +1826,10 @@ eslint-plugin-es@^1.3.1:
     eslint-utils "^1.3.0"
     regexpp "^2.0.0"
 
-eslint-plugin-jest@^21.25.1:
-  version "21.26.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.26.1.tgz#73c5d6838d384fe6a9644077c27011bd99665ff2"
+eslint-plugin-jest@^22.0.0:
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.0.0.tgz#87dc52bbdd47f37f23bf2b10bb8469458bb3ed68"
+  integrity sha512-YOj8cYI5ZXEZUrX2kUBLachR1ffjQiicIMBoivN7bXXHnxi8RcwNvmVzwlu3nTmjlvk5AP3kIpC5i8HcinmhPA==
 
 eslint-plugin-lodash@^3.1.0:
   version "3.1.0"
@@ -1835,13 +1837,14 @@ eslint-plugin-lodash@^3.1.0:
   dependencies:
     lodash "4.17.10"
 
-eslint-plugin-node@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz#a6e054e50199b2edd85518b89b4e7b323c9f36db"
+eslint-plugin-node@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-8.0.0.tgz#fb9e8911f4543514f154bb6a5924b599aa645568"
+  integrity sha512-Y+ln8iQ52scz9+rSPnSWRaAxeWaoJZ4wIveDR0vLHkuSZGe44Vk1J4HX7WvEP5Cm+iXPE8ixo7OM7gAO3/OKpQ==
   dependencies:
     eslint-plugin-es "^1.3.1"
     eslint-utils "^1.3.1"
-    ignore "^4.0.2"
+    ignore "^5.0.2"
     minimatch "^3.0.4"
     resolve "^1.8.1"
     semver "^5.5.0"
@@ -2735,9 +2738,14 @@ ignore@^3.3.5:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
-ignore@^4.0.0, ignore@^4.0.2, ignore@^4.0.6:
+ignore@^4.0.0, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+
+ignore@^5.0.2:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.0.4.tgz#33168af4a21e99b00c5d41cbadb6a6cb49903a45"
+  integrity sha512-WLsTMEhsQuXpCiG173+f3aymI43SXa+fB1rSfbzyP4GkPP+ZFVuO0/3sFUGNBtifisPeDcl/uD/Y2NxZ7xFq4g==
 
 import-lazy@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Enable `eslint-config-stylelint`, which was installed, but not used. It has probably been disabled because it warns for ES6 imports. I changed the config to turn of that error.

I also ran `eslint-plugin-eslint-comments` plugin and fixed warnings that it printed. It's not added to `package.json` because it might be included in `eslint-config-stylelint`.