### PR TITLE
at-function-named-arguments: correctly parse functions inside Sass maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# HEAD
+
+- Fixed: `at-function-named-arguments` was not correctly handling functions inside Sass maps.
+
 # 3.4.0
 
 - Added: `at-mixin-argumentless-call-parentheses` autofix (#280).

--- a/src/rules/at-function-named-arguments/__tests__/index.js
+++ b/src/rules/at-function-named-arguments/__tests__/index.js
@@ -163,6 +163,18 @@ testRule(rule, {
       ) !default;
       `,
       description: "Always. Should ignore Sass maps with default."
+    },
+    {
+      code: `
+      $color: #123456;
+
+      $rgb: (
+        "r": red($red: $color),
+        "g": green($green: $color),
+        "b": blue($blue: $color)
+      );
+      `,
+      description: "Always. function call inside a map."
     }
   ],
 
@@ -261,6 +273,18 @@ testRule(rule, {
       column: 9,
       description:
         "Always. Example: native CSS function inside a function call."
+    },
+    {
+      code: `
+      $color: #123456;
+
+      $rgb: (
+        "r": red($color),
+        "g": green($color),
+        "b": blue($color)
+      );
+      `,
+      description: "Always. function call inside a map."
     }
   ]
 });
@@ -519,8 +543,19 @@ testRule(rule, {
       line: 3,
       column: 9,
       message: messages.rejected,
-      description:
-        "Always. Example: native CSS function inside a function call."
+      description: "Never. Example: native CSS function inside a function call."
+    },
+    {
+      code: `
+      $color: #123456;
+
+      $rgb: (
+        "r": red($red: $color),
+        "g": green($green: $color),
+        "b": blue($green: $color)
+      );
+      `,
+      description: "Never. function call inside a map."
     }
   ]
 });

--- a/src/rules/at-function-named-arguments/__tests__/index.js
+++ b/src/rules/at-function-named-arguments/__tests__/index.js
@@ -1,4 +1,4 @@
-import rule, { ruleName, messages } from "..";
+import rule, { messages, ruleName } from "..";
 
 // Required ("always")
 testRule(rule, {
@@ -377,7 +377,19 @@ testRule(rule, {
       }
       `,
       description:
-        "Always. Example: native CSS function is ignored inside a function call."
+        "Never. Example: native CSS function is ignored inside a function call."
+    },
+    {
+      code: `
+      $color: #123456;
+
+      $rgb: (
+        "r": red($color),
+        "g": green($color),
+        "b": blue($color)
+      );
+      `,
+      description: "Never. function call inside a map."
     }
   ],
 

--- a/src/rules/at-function-named-arguments/index.js
+++ b/src/rules/at-function-named-arguments/index.js
@@ -1,12 +1,12 @@
-import { utils } from "stylelint";
-import {
-  namespace,
-  optionsHaveIgnored,
-  isNativeCssFunction,
-  parseFunctionArguments
-} from "../../utils";
 import { isString } from "lodash";
 import valueParser from "postcss-value-parser";
+import { utils } from "stylelint";
+import {
+  isNativeCssFunction,
+  namespace,
+  optionsHaveIgnored,
+  parseFunctionArguments
+} from "../../utils";
 
 export const ruleName = namespace("at-function-named-arguments");
 
@@ -74,7 +74,7 @@ export default function(expectation, options) {
           return;
         }
 
-        const args = parseFunctionArguments(decl.value);
+        const args = parseFunctionArguments(valueParser.stringify(node));
         const isSingleArgument = args.length === 1;
 
         if (isSingleArgument && shouldIgnoreSingleArgument) {


### PR DESCRIPTION
Fixes #289