### PR TITLE
[#197] - New rule to enforce nesting

### DIFF
--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -36,6 +36,7 @@ import operatorNoNewlineBefore from "./operator-no-newline-before";
 import operatorNoUnspaced from "./operator-no-unspaced";
 import partialNoImport from "./partial-no-import";
 import percentPlaceholderPattern from "./percent-placeholder-pattern";
+import selectorNestCombinators from "./selector-nest-combinators";
 import selectorNoRedundantNestingSelector from "./selector-no-redundant-nesting-selector";
 
 export default {
@@ -77,5 +78,6 @@ export default {
   "operator-no-unspaced": operatorNoUnspaced,
   "percent-placeholder-pattern": percentPlaceholderPattern,
   "partial-no-import": partialNoImport,
+  "selector-nest-combinators": selectorNestCombinators,
   "selector-no-redundant-nesting-selector": selectorNoRedundantNestingSelector
 };

--- a/src/rules/selector-nest-combinators/README.md
+++ b/src/rules/selector-nest-combinators/README.md
@@ -1,0 +1,221 @@
+# selector-nest-combinators
+
+Require or disallow nesting of combinators in selectors
+
+```scss
+/* Examples of selectors without nesting of combinators */
+.foo .bar {}
+
+.foo.bar {}
+
+.foo > .bar {}
+
+.foo:hover {}
+
+/* Corresponding selectors with combinators nested */
+.foo {
+  .bar {}
+}
+
+.foo {
+  &.bar {}
+}
+
+.foo {
+  & > .bar {}
+}
+
+.foo {
+  &:hover {}
+}
+```
+
+## Options
+
+`string`: `"always"|"never"`
+
+### `"always"`
+
+*Every combinator* in a selector *must be* nested where possible without altering the existing resolved selector.
+
+Sections of selectors preceding a parent selector are ignored with `always`.
+e.g.
+
+```scss
+.foo {
+  .bar.baz & {}
+}
+```
+
+Sections of selectors within pseudo selectors are also ignored with `always`.
+e.g.
+
+```scss
+.foo {
+  &:not(.bar .baz) {}
+}
+```
+
+while this could be refactored to:
+
+```scss
+.bar {
+  .baz {
+    .foo:not(&) {}
+  }
+}
+```
+
+There are variances in the way this is compiled between compilers, therefore for the purposes of this rule the selector sections within pseudo selectors are being ignored.
+
+The following patterns are considered warnings:
+
+```scss
+.foo .bar {}
+```
+
+```scss
+.foo.bar {}
+```
+
+```scss
+.foo > .bar {}
+```
+
+```scss
+.foo:hover {}
+```
+
+```scss
+a[href] {}
+```
+
+```scss
+* + li {}
+```
+
+```scss
+:nth-child(2n - 1):last-child {}
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+.foo {
+  .bar {}
+}
+```
+
+```scss
+.foo {
+  &.bar {}
+}
+```
+
+```scss
+.foo {
+  & > .bar {}
+}
+```
+
+```scss
+.foo {
+  &:hover {}
+}
+```
+
+```scss
+a {
+  &[href] {}
+}
+```
+
+```scss
+* {
+  & + li {}
+}
+```
+
+```scss
+:nth-child(2n - 1) {
+  &:last-child {}
+}
+```
+
+### `"never"`
+
+Nested of selectors are not allowed.
+
+The following patterns are considered warnings:
+
+```scss
+.foo {
+  .bar {}
+}
+```
+
+```scss
+.foo {
+  &.bar {}
+}
+```
+
+```scss
+.foo {
+  & > .bar {}
+}
+```
+
+```scss
+.foo {
+  &:hover {}
+}
+```
+
+```scss
+a {
+  &[href] {}
+}
+```
+
+```scss
+* {
+  & + li {}
+}
+```
+
+```scss
+:nth-child(2n - 1) {
+  &:last-child {}
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+.foo .bar {}
+```
+
+```scss
+.foo.bar {}
+```
+
+```scss
+.foo > .bar {}
+```
+
+```scss
+.foo:hover {}
+```
+
+```scss
+a[href] {}
+```
+
+```scss
+* + li {}
+```
+
+```scss
+:nth-child(2n - 1):last-child {}
+```

--- a/src/rules/selector-nest-combinators/__tests__/index.js
+++ b/src/rules/selector-nest-combinators/__tests__/index.js
@@ -1,0 +1,293 @@
+import rule, { ruleName, messages } from "..";
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "scss",
+
+  accept: [
+    {
+      code: `
+      .foo {
+        .bar {}
+      }
+      `,
+      description: "when child combinators are nested"
+    },
+    {
+      code: `
+      .foo {
+        &.bar {}
+      }
+      `,
+      description: "when chained combinators are nested"
+    },
+    {
+      code: `
+      .foo {
+        & > bar {}
+      }
+      `,
+      description: "when direct descendant combinators are nested"
+    },
+    {
+      code: `
+      .baz {
+        .foo.bar & {}
+      }
+      `,
+      description:
+        "when chained combinators can't be nested due to preceding a parent selector"
+    },
+    {
+      code: `
+      .foo {
+        &bar {
+          &baz {}
+        }
+      }
+      `,
+      description: "when parent selectors are used for concatenation"
+    },
+    {
+      code: `
+      .foo {
+        &__bar {
+          &--baz {}
+        }
+      }
+      `,
+      description: "when parent selectors are used for BEM style concatenation"
+    },
+    {
+      code: `
+      .foo {
+        &:hover {}
+      }
+      `,
+      description: "when pseudo classes are nested"
+    },
+    {
+      code: `
+      .foo {
+        &:nth-child(2n - 1) {}
+      }
+      `,
+      description: "when an nth child selector is used which includes spaces"
+    },
+    {
+      code: `
+      [data-test="foo bar"] {}
+      `,
+      description: "when an attribute selector is used with spaces in it"
+    },
+    {
+      code: `
+      :not([class]:last-child) {}
+      `,
+      description: "when selectors are chained within a not selector"
+    }
+  ],
+
+  reject: [
+    {
+      code: `
+      .foo .bar {}
+      `,
+      description: "when a child combinator is used instead of nesting",
+      messages: messages.rejected("child combinator"),
+      line: 2,
+      column: 12
+    },
+    {
+      code: `
+      .foo.bar {}
+      `,
+      description: "when a selector is chained with another",
+      messages: messages.rejected("chaining"),
+      line: 2,
+      column: 11
+    },
+    {
+      code: `
+      .foo > .bar {}
+      `,
+      description:
+        "when a direct descendant combinator is used without nesting",
+      messages: messages.rejected("direct descendant"),
+      line: 2,
+      column: 14
+    },
+    {
+      code: `
+      .foo:hover {}
+      `,
+      description: "when pseudo classes are used without nesting",
+      messages: messages.rejected("pseudo class"),
+      line: 2,
+      column: 11
+    },
+    {
+      code: `
+      * + li {}
+      `,
+      description: "when universal selectors are used with a combinator",
+      messages: messages.rejected("direct sibling"),
+      line: 2,
+      column: 11
+    },
+    {
+      code: `
+      :nth-child(2n - 1):last-child {}
+      `,
+      description: "when pseudo selectors only are chained",
+      messages: messages.rejected("pseudo class"),
+      line: 2,
+      column: 25
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  syntax: "scss",
+
+  accept: [
+    {
+      code: `
+      .foo .bar {}
+      `,
+      description: "when a child combinator is used instead of nesting"
+    },
+    {
+      code: `
+      .foo.bar {}
+      `,
+      description: "when a selector is chained with another"
+    },
+    {
+      code: `
+      .foo > .bar {}
+      `,
+      description: "when a direct descendant combinator is used without nesting"
+    },
+    {
+      code: `
+      .foo:hover {}
+      `,
+      description: "when pseudo classes are used without nesting"
+    },
+    {
+      code: `
+      @media screen {
+        .foo {}
+      }
+      `,
+      description: "when selectors are nested inside @media"
+    },
+    {
+      code: `
+      @keyframes foo {
+        0% {}
+        100% {}
+      }
+      `,
+      description: "when a keyframes rule is used"
+    },
+    {
+      code: `
+      @include mixin {
+        .foo {}
+      }
+      `,
+      description:
+        "when selectors are nested in a mixin, e.g. when making use of @content"
+    },
+    {
+      code: `
+      .foo:nth-child(2n-1) {}
+      `,
+      description: "when using an nth-child selector"
+    },
+    {
+      code: `
+      #foo:not([class]:last-child) {}
+      `,
+      description: "when using a not selector"
+    }
+  ],
+
+  reject: [
+    {
+      code: `
+      .foo {
+        .bar {}
+      }
+      `,
+      description: "when child combinators are nested",
+      messages: messages.rejected("nesting"),
+      line: 3,
+      column: 9
+    },
+    {
+      code: `
+      .foo {
+        &.bar {}
+      }
+      `,
+      description: "when chained combinators are nested",
+      messages: messages.rejected("nesting"),
+      line: 3,
+      column: 9
+    },
+    {
+      code: `
+      .foo {
+        & > bar {}
+      }
+      `,
+      description: "when direct descendant combinators are nested",
+      messages: messages.rejected("nesting"),
+      line: 3,
+      column: 9
+    },
+    {
+      code: `
+      .foo {
+        &bar {
+          &baz {}
+        }
+      }
+      `,
+      description: "when parent selectors are used for concatenation",
+      messages: messages.rejected("nesting"),
+      line: 3,
+      column: 9
+    },
+    {
+      code: `
+      .foo {
+        &__bar {
+          &--baz {}
+        }
+      }
+      `,
+      description: "when parent selectors are used for BEM style concatenation",
+      messages: messages.rejected("nesting"),
+      line: 3,
+      column: 9
+    },
+    {
+      code: `
+      .foo {
+        &:hover {}
+      }
+      `,
+      description: "when pseudo classes are nested",
+      messages: messages.rejected("nesting"),
+      line: 3,
+      column: 9
+    }
+  ]
+});

--- a/src/rules/selector-nest-combinators/index.js
+++ b/src/rules/selector-nest-combinators/index.js
@@ -1,0 +1,109 @@
+import { utils } from "stylelint";
+import { namespace, parseSelector } from "../../utils";
+
+export const ruleName = namespace("selector-nest-combinators");
+
+export const messages = utils.ruleMessages(ruleName, {
+  expected: prop => `Expected selector "${prop}" to be in a nested form`,
+  rejected: prop => `Unexpected "${prop}" found in selector`
+});
+
+export default function(expectation) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: ["always", "never"]
+    });
+
+    if (!validOptions) {
+      return;
+    }
+
+    root.walkRules(rule => {
+      parseSelector(rule.selector, result, rule, fullSelector => {
+        // attribute, class, combinator, comment, id, nesting, pseudo, root, selector, string, tag, or universal
+        const chainingTypes = [
+          "attribute",
+          "class",
+          "id",
+          "pseudo",
+          "tag",
+          "universal"
+        ];
+
+        fullSelector.walk(node => {
+          if (expectation === "always") {
+            if (node.type === "selector") {
+              return;
+            }
+
+            if (
+              node.parent &&
+              node.parent.type === "selector" &&
+              node.parent.parent &&
+              node.parent.parent.type === "pseudo"
+            ) {
+              return;
+            }
+
+            if (!node.prev()) {
+              return;
+            }
+
+            if (node.next() && precedesParentSelector(node)) {
+              return;
+            }
+
+            if (!chainingTypes.includes(node.type)) {
+              return;
+            }
+
+            if (node.prev().type === "combinator") {
+              if (!node.prev().prev()) {
+                return;
+              }
+
+              if (!chainingTypes.includes(node.prev().prev().type)) {
+                return;
+              }
+            }
+
+            if (
+              node.prev().type !== "combinator" &&
+              chainingTypes.includes(node.type) &&
+              !chainingTypes.includes(node.prev().type)
+            ) {
+              return;
+            }
+          }
+
+          if (expectation === "never") {
+            if (rule.parent.type === "root" || rule.parent.type === "atrule") {
+              return;
+            }
+          }
+
+          utils.report({
+            ruleName,
+            result,
+            node: rule,
+            message: messages.rejected,
+            index: node.sourceIndex
+          });
+
+          function precedesParentSelector(current) {
+            do {
+              current = current.next();
+
+              if (current.type === "nesting") {
+                return true;
+              }
+            } while (current.next());
+
+            return false;
+          }
+        });
+      });
+    });
+  };
+}


### PR DESCRIPTION
Added a new rule called `selector-nest-combinator` as well as a README and tests.

Currently the only options are `always` and `never`. This rule may be more useful with more options, such as `pseudo-only` or exceptions such as `attribute`.