### PR TITLE
Fix "unxpected" typo in error messages

### DIFF
--- a/src/rules/at-else-empty-line-before/index.js
+++ b/src/rules/at-else-empty-line-before/index.js
@@ -4,7 +4,7 @@ import { utils } from "stylelint";
 export const ruleName = namespace("at-else-empty-line-before");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Unxpected empty line before @else"
+  rejected: "Unexpected empty line before @else"
 });
 
 export default function(expectation, _, context) {

--- a/src/rules/dollar-variable-empty-line-before/index.js
+++ b/src/rules/dollar-variable-empty-line-before/index.js
@@ -13,7 +13,7 @@ export const ruleName = namespace("dollar-variable-empty-line-before");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected an empty line before $-variable",
-  rejected: "Unxpected empty line before $-variable"
+  rejected: "Unexpected empty line before $-variable"
 });
 
 export default function(expectation, options, context) {


### PR DESCRIPTION
"Unexpected" was typod as "unxpected" in at-else-empty-line-before and
dollar-variable-empty-line-before messages.