### PR TITLE
Do not use "/*" in comments

### DIFF
--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -34,6 +34,7 @@ import functionNoUnquotedStrings from "./function-unquote-no-unquoted-strings-in
 import mediaFeatureValueDollarVariable from "./media-feature-value-dollar-variable";
 import noDollarVariables from "./no-dollar-variables";
 import noDuplicateDollarVariables from "./no-duplicate-dollar-variables";
+import noLoudComments from "./no-loud-comments";
 import operatorNoNewlineAfter from "./operator-no-newline-after";
 import operatorNoNewlineBefore from "./operator-no-newline-before";
 import operatorNoUnspaced from "./operator-no-unspaced";
@@ -79,6 +80,7 @@ export default {
   "media-feature-value-dollar-variable": mediaFeatureValueDollarVariable,
   "no-dollar-variables": noDollarVariables,
   "no-duplicate-dollar-variables": noDuplicateDollarVariables,
+  "no-loud-comments": noLoudComments,
   "operator-no-newline-after": operatorNoNewlineAfter,
   "operator-no-newline-before": operatorNoNewlineBefore,
   "operator-no-unspaced": operatorNoUnspaced,

--- a/src/rules/no-loud-comments/README.md
+++ b/src/rules/no-loud-comments/README.md
@@ -1,0 +1,27 @@
+# no-loud-comments
+
+Disallow `/*`-comments.
+
+```scss
+/*  Comment */
+//  ↑     ↑
+// This line
+```
+
+This rule only works on CSS comments (`/* */`) and ignores all double-slash (`//`) comments.
+
+## Options
+
+### `true`
+
+The following patterns are considered violations:
+
+```scss
+/* comment */
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+// comment
+```

--- a/src/rules/no-loud-comments/__tests__/index.js
+++ b/src/rules/no-loud-comments/__tests__/index.js
@@ -1,0 +1,45 @@
+import rule, { ruleName, messages } from "..";
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "scss",
+
+  accept: [
+    {
+      code: "// comment",
+      description: "Double slash comments"
+    }
+  ],
+  reject: [
+    {
+      code: `
+      /* comment */
+    `,
+      description: "One line with optional ending",
+      message: messages.expected
+    },
+    {
+      code: "/* comment",
+      description: "One line with no ending",
+      message: messages.expected
+    },
+    {
+      code: `
+        /* comment line 1
+           comment line 2 
+    `,
+      description: "Multliine comment with no ending",
+      message: messages.expected
+    },
+    {
+      code: `
+        /* comment line 1
+           comment line 2 
+        */
+    `,
+      description: "Multliine comment with optional ending on next line",
+      message: messages.expected
+    }
+  ]
+});

--- a/src/rules/no-loud-comments/index.js
+++ b/src/rules/no-loud-comments/index.js
@@ -1,0 +1,37 @@
+import { utils } from "stylelint";
+import { namespace } from "../../utils";
+
+export const ruleName = namespace("no-loud-comments");
+
+export const messages = utils.ruleMessages(ruleName, {
+  rejected: "Use // for comments instead of /*"
+});
+
+function rule(primary) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary
+    });
+
+    if (!validOptions) {
+      return;
+    }
+
+    root.walkComments(comment => {
+      if (isLoudComment(comment)) {
+        utils.report({
+          message: messages.rejected,
+          node: comment,
+          result,
+          ruleName
+        });
+      }
+    });
+  };
+}
+
+function isLoudComment(comment) {
+  return comment.source.input.css.includes("/*");
+}
+
+export default rule;


### PR DESCRIPTION
sass/linter had a [rule](https://github.com/sass/linter/blob/master/lib/src/rules/no_loud_comment.dart) about "loud comments" (using /* for comments).

This rule verifies that you are not using /* in comments.

(I'm not sure if loud comments are a known thing, so I can change the rule name)