### PR TITLE
New rule: `at-if-no-null`

### DIFF
--- a/src/rules/at-if-no-null/README.md
+++ b/src/rules/at-if-no-null/README.md
@@ -4,7 +4,7 @@ Check for equality to null is unnecessarily explicit since `null` is falsey in S
 
 ```scss
 a {
-    @if ($x == null) {}
+    @if $x == null {}
 /**         ↑     ↑
  * == or != null is unncessary */
 }
@@ -12,20 +12,20 @@ a {
 
 ## Options
 
-always
+true
 
-### `always`
+### `true`
 
 The following patterns are considered warnings:
 ```scss
 a {
-    @if ($x == null) {}
+    @if $x == null {}
 }
 ```
 
 ```scss
 a {
-    @if ($x != null) {}
+    @if $x != null {}
 }
 ```
 
@@ -33,12 +33,12 @@ The following patterns are *not* considered warnings:
 
 ```scss
 a {
-    @if ($x) {}
+    @if $x {}
 }
 ```
 
 ```scss
 a {
-    @if not ($x) {}
+    @if not $x {}
 }
 ```

--- a/src/rules/at-if-no-null/README.md
+++ b/src/rules/at-if-no-null/README.md
@@ -1,1 +1,44 @@
 # at-if-no-null
+
+Check for equality to null is unnecessarily explicit since `null` is falsey in Sass.
+
+```scss
+a {
+    @if ($x == null) {}
+/**         ↑     ↑
+ * == or != null is unncessary */
+}
+```
+
+## Options
+
+always
+
+### `always`
+
+The following patterns are considered warnings:
+```scss
+a {
+    @if ($x == null) {}
+}
+```
+
+```scss
+a {
+    @if ($x != null) {}
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+a {
+    @if ($x) {}
+}
+```
+
+```scss
+a {
+    @if not ($x) {}
+}
+```

--- a/src/rules/at-if-no-null/README.md
+++ b/src/rules/at-if-no-null/README.md
@@ -1,0 +1,1 @@
+# at-if-no-null

--- a/src/rules/at-if-no-null/__tests__/index.js
+++ b/src/rules/at-if-no-null/__tests__/index.js
@@ -4,7 +4,6 @@ testRule(rule, {
   ruleName,
   config: [true],
   syntax: "scss",
-  fix: true,
 
   accept: [
     {
@@ -28,7 +27,7 @@ testRule(rule, {
     }`,
       description: "uses the == null format",
       message: messages.equals_null,
-      line: 4
+      line: 2
     },
     {
       code: `a {
@@ -36,7 +35,7 @@ testRule(rule, {
     }`,
       description: "uses the != null format",
       message: messages.not_equals_null,
-      line: 4
+      line: 2
     }
   ]
 });

--- a/src/rules/at-if-no-null/__tests__/index.js
+++ b/src/rules/at-if-no-null/__tests__/index.js
@@ -2,7 +2,7 @@ import rule, { ruleName, messages } from "..";
 
 testRule(rule, {
   ruleName,
-  config: ["always-last-in-chain"],
+  config: [true],
   syntax: "scss",
   fix: true,
 
@@ -27,7 +27,7 @@ testRule(rule, {
       @if ($x == null) {}
     }`,
       description: "uses the == null format",
-      message: messages.expected,
+      message: messages.equals_null,
       line: 4
     },
     {
@@ -35,7 +35,7 @@ testRule(rule, {
       @if ($x != null) {}
     }`,
       description: "uses the != null format",
-      message: messages.expected,
+      message: messages.not_equals_null,
       line: 4
     }
   ]

--- a/src/rules/at-if-no-null/__tests__/index.js
+++ b/src/rules/at-if-no-null/__tests__/index.js
@@ -1,0 +1,38 @@
+import rule, { ruleName, messages } from "..";
+
+testRule(rule, {
+  ruleName,
+  config: ["always-last-in-chain"],
+  syntax: "scss",
+  fix: true,
+
+  accept: [
+    {
+      code: `a {
+      @if ($x == 1) {}
+      width: 10px;
+    }`,
+      description: "always-last-in-chain (no @else, has newline after)."
+    }
+  ],
+
+  reject: [
+    {
+      code: `a {
+      @if ($x == 1) {
+
+      } width: 10px;
+    }`,
+      fixed: `a {
+      @if ($x == 1) {
+
+      }
+width: 10px;
+    }`,
+      description:
+        "always-last-in-chain (has decl on the same line as its closing brace).",
+      message: messages.expected,
+      line: 4
+    }
+  ]
+});

--- a/src/rules/at-if-no-null/__tests__/index.js
+++ b/src/rules/at-if-no-null/__tests__/index.js
@@ -17,6 +17,12 @@ testRule(rule, {
       @if not $x {}
     }`,
       description: "does not use the == null format"
+    },
+    {
+      code: `a {
+      @if $x != null and $x > 1 {}
+    }`,
+      description: "does not use the == null format"
     }
   ],
 

--- a/src/rules/at-if-no-null/__tests__/index.js
+++ b/src/rules/at-if-no-null/__tests__/index.js
@@ -8,13 +8,13 @@ testRule(rule, {
   accept: [
     {
       code: `a {
-      @if ($x) {}
+      @if $x {}
     }`,
       description: "does not use the != null format"
     },
     {
       code: `a {
-      @if not ($x) {}
+      @if not $x {}
     }`,
       description: "does not use the == null format"
     }
@@ -23,7 +23,7 @@ testRule(rule, {
   reject: [
     {
       code: `a {
-      @if ($x == null) {}
+      @if $x == null {}
     }`,
       description: "uses the == null format",
       message: messages.equals_null,
@@ -31,7 +31,7 @@ testRule(rule, {
     },
     {
       code: `a {
-      @if ($x != null) {}
+      @if $x != null {}
     }`,
       description: "uses the != null format",
       message: messages.not_equals_null,

--- a/src/rules/at-if-no-null/__tests__/index.js
+++ b/src/rules/at-if-no-null/__tests__/index.js
@@ -9,28 +9,32 @@ testRule(rule, {
   accept: [
     {
       code: `a {
-      @if ($x == 1) {}
-      width: 10px;
+      @if ($x) {}
     }`,
-      description: "always-last-in-chain (no @else, has newline after)."
+      description: "does not use the != null format"
+    },
+    {
+      code: `a {
+      @if not ($x) {}
+    }`,
+      description: "does not use the == null format"
     }
   ],
 
   reject: [
     {
       code: `a {
-      @if ($x == 1) {
-
-      } width: 10px;
+      @if ($x == null) {}
     }`,
-      fixed: `a {
-      @if ($x == 1) {
-
-      }
-width: 10px;
+      description: "uses the == null format",
+      message: messages.expected,
+      line: 4
+    },
+    {
+      code: `a {
+      @if ($x != null) {}
     }`,
-      description:
-        "always-last-in-chain (has decl on the same line as its closing brace).",
+      description: "uses the != null format",
       message: messages.expected,
       line: 4
     }

--- a/src/rules/at-if-no-null/index.js
+++ b/src/rules/at-if-no-null/index.js
@@ -4,8 +4,8 @@ import { utils } from "stylelint";
 export const ruleName = namespace("at-if-no-null");
 
 export const messages = utils.ruleMessages(ruleName, {
-  equals_null: "Expected @if(statement) rather than @if(statement == null)",
-  not_equals_null: "Expected @if(!statement) rather than @if(statement != null)"
+  equals_null: "Expected @if not statement rather than @if statement == null",
+  not_equals_null: "Expected @if statement rather than @if statement != null"
 });
 
 export default function(expectation) {

--- a/src/rules/at-if-no-null/index.js
+++ b/src/rules/at-if-no-null/index.js
@@ -24,14 +24,14 @@ export default function(expectation) {
         return;
       }
 
-      if (atrule.params.match(/\([ \t]*.* == null[ \t]*\)/)) {
+      if (atrule.params.match(/\(?[ \t]*.* == null[ \t]*\)?/)) {
         utils.report({
           message: messages.equals_null,
           node: atrule,
           result,
           ruleName
         });
-      } else if (atrule.params.match(/\([ \t]*.* != null[ \t]*\)/)) {
+      } else if (atrule.params.match(/\(?[ \t]*.* != null[ \t]*\)?/)) {
         utils.report({
           message: messages.not_equals_null,
           node: atrule,

--- a/src/rules/at-if-no-null/index.js
+++ b/src/rules/at-if-no-null/index.js
@@ -1,0 +1,10 @@
+import { isSingleLineString, namespace } from "../../utils";
+import { utils } from "stylelint";
+import { isBoolean } from "lodash";
+
+export const ruleName = namespace("at-if-no-null");
+
+export const messages = utils.ruleMessages(ruleName, {
+  equals_null: "Expected @if(statement) rather than @if(statement == null)",
+  not_equals_null: "Expected @if(!statement) rather than @if(statement != null)"
+});

--- a/src/rules/at-if-no-null/index.js
+++ b/src/rules/at-if-no-null/index.js
@@ -18,5 +18,28 @@ export default function(expectation, _, context) {
     if (!validOptions) {
       return;
     }
+
+    root.walkAtRules(atrule => {
+      // Do nothing if it's not an @if
+      if (atrule.name !== "if") {
+        return;
+      }
+
+      if (atrule.params.match(/\(.* == null\)/)) {
+        utils.report({
+          message: messages.equals_null,
+          node: atrule,
+          result,
+          ruleName
+        });
+      } else if (atrule.params.match(/\(.* != null \)/)) {
+        utils.report({
+          message: messages.not_equals_null,
+          node: atrule,
+          result,
+          ruleName
+        });
+      }
+    });
   };
 }

--- a/src/rules/at-if-no-null/index.js
+++ b/src/rules/at-if-no-null/index.js
@@ -24,6 +24,11 @@ export default function(expectation) {
         return;
       }
 
+      // If rule != null and (expr), skip
+      if (atrule.params.match(/\(?[ \t]*.* != null and .*\)?/)) {
+        return;
+      }
+
       if (atrule.params.match(/\(?[ \t]*.* == null[ \t]*\)?/)) {
         utils.report({
           message: messages.equals_null,

--- a/src/rules/at-if-no-null/index.js
+++ b/src/rules/at-if-no-null/index.js
@@ -1,6 +1,5 @@
-import { isSingleLineString, namespace } from "../../utils";
+import { namespace } from "../../utils";
 import { utils } from "stylelint";
-import { isBoolean } from "lodash";
 
 export const ruleName = namespace("at-if-no-null");
 
@@ -9,7 +8,7 @@ export const messages = utils.ruleMessages(ruleName, {
   not_equals_null: "Expected @if(!statement) rather than @if(statement != null)"
 });
 
-export default function(expectation, _, context) {
+export default function(expectation) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation
@@ -25,14 +24,14 @@ export default function(expectation, _, context) {
         return;
       }
 
-      if (atrule.params.match(/\(.* == null\)/)) {
+      if (atrule.params.match(/\([ \t]*.* == null[ \t]*\)/)) {
         utils.report({
           message: messages.equals_null,
           node: atrule,
           result,
           ruleName
         });
-      } else if (atrule.params.match(/\(.* != null \)/)) {
+      } else if (atrule.params.match(/\([ \t]*.* != null[ \t]*\)/)) {
         utils.report({
           message: messages.not_equals_null,
           node: atrule,

--- a/src/rules/at-if-no-null/index.js
+++ b/src/rules/at-if-no-null/index.js
@@ -8,3 +8,15 @@ export const messages = utils.ruleMessages(ruleName, {
   equals_null: "Expected @if(statement) rather than @if(statement == null)",
   not_equals_null: "Expected @if(!statement) rather than @if(statement != null)"
 });
+
+export default function(expectation, _, context) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: expectation
+    });
+
+    if (!validOptions) {
+      return;
+    }
+  };
+}

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -8,6 +8,7 @@ import atFunctionParenthesesSpaceBefore from "./at-function-parentheses-space-be
 import atFunctionPattern from "./at-function-pattern";
 import atIfClosingBraceNewlineAfter from "./at-if-closing-brace-newline-after";
 import atIfClosingBraceSpaceAfter from "./at-if-closing-brace-space-after";
+import atIfNoNull from "./at-if-no-null";
 import atImportNoPartialLeadingUnderscore from "./at-import-no-partial-leading-underscore";
 import atImportPartialExtensionBlacklist from "./at-import-partial-extension-blacklist";
 import atImportPartialExtensionWhitelist from "./at-import-partial-extension-whitelist";
@@ -57,6 +58,7 @@ export default {
   "at-function-pattern": atFunctionPattern,
   "at-if-closing-brace-newline-after": atIfClosingBraceNewlineAfter,
   "at-if-closing-brace-space-after": atIfClosingBraceSpaceAfter,
+  "at-if-no-null": atIfNoNull,
   "at-import-no-partial-leading-underscore": atImportNoPartialLeadingUnderscore,
   "at-import-partial-extension-blacklist": atImportPartialExtensionBlacklist,
   "at-import-partial-extension-whitelist": atImportPartialExtensionWhitelist,


### PR DESCRIPTION
The [sass/linter](https://github.com/sass/linter/blob/master/lib/src/rules/use_falsey_null.dart) project had a rule to check for using `== null` or `!= null` inside @if statements.

This rule replicates that.