### PR TITLE
Fix selector-no-union-class-name throwing when parent.selector is undefined

### DIFF
--- a/src/rules/selector-no-union-class-name/__tests__/index.js
+++ b/src/rules/selector-no-union-class-name/__tests__/index.js
@@ -95,6 +95,20 @@ testRule(rule, {
       }
       `,
       description: "ignores an ampersand chained with an attribute"
+    },
+    {
+      code: `
+      @mixin demo() {
+        @content;
+      }
+      .a-selector {
+        @include demo() {
+          button:hover & {
+  	        background:purple
+          }
+        }
+      }`,
+      description: "should not throw an error when using nesting (issue #345)"
     }
   ],
 

--- a/src/rules/selector-no-union-class-name/index.js
+++ b/src/rules/selector-no-union-class-name/index.js
@@ -35,9 +35,13 @@ export default function(actual) {
     root.walkRules(/&/, rule => {
       const parentNodes = [];
 
-      parseSelector(rule.parent.selector, result, rule, fullSelector => {
-        fullSelector.walk(node => parentNodes.push(node));
-      });
+      if (rule.parent && rule.parent.selector) {
+        parseSelector(rule.parent.selector, result, rule, fullSelector => {
+          fullSelector.walk(node => parentNodes.push(node));
+        });
+      }
+
+      if (parentNodes.length === 0) return;
 
       const lastParentNode = parentNodes[parentNodes.length - 1];
 


### PR DESCRIPTION


Fixes #345