### PR TITLE
Fix error reporting for dimension-no-non-numeric-values

### DIFF
--- a/src/rules/dimension-no-non-numeric-values/index.js
+++ b/src/rules/dimension-no-non-numeric-values/index.js
@@ -1,12 +1,12 @@
-import { utils } from "stylelint";
-import { namespace } from "../../utils";
 import valueParser from "postcss-value-parser";
+import { utils } from "stylelint";
+import { declarationValueIndex, namespace } from "../../utils";
 
 export const ruleName = namespace("dimension-no-non-numeric-values");
 
 export const messages = utils.ruleMessages(ruleName, {
   rejected: unit =>
-    `Expected "$value * 1${unit}" instead of "#{value}${unit}". Consider writing "value" in terms of ${unit} originally.`
+    `Expected "$value * 1${unit}" instead of "#{$value}${unit}". Consider writing "value" in terms of ${unit} originally.`
 });
 
 export const units = [
@@ -91,10 +91,18 @@ export default function rule(primary) {
           return;
         }
 
+        const regex = new RegExp(
+          "#{[$a-z_0-9 +-]*}(" + units.join("|") + ");?"
+        );
+        const matchUnit = decl.value.match(regex);
+        const unit = matchUnit[1];
+        const offset = decl.value.indexOf(unit);
+
         utils.report({
           ruleName,
           result,
-          message: messages.rejected,
+          message: messages.rejected(unit),
+          index: declarationValueIndex(decl) + offset,
           node: decl
         });
       });


### PR DESCRIPTION
Fix following issues related to the `dimension-no-non-numeric-values` rule:

- Rejected message was throwing an error because it was called without the unit.
- Change highlighted error to point to the unit that is used with the interpolation, instead of it pointing to the property name. That makes much more sense if you are using this rule with CSS shorthand properties.

Fixes #363

Please review @rambleraptor @fuhlig