### PR TITLE
at-rule-no-unknown: remove duplicate looping logic

### DIFF
--- a/src/rules/at-rule-no-unknown/__tests__/index.js
+++ b/src/rules/at-rule-no-unknown/__tests__/index.js
@@ -1,4 +1,9 @@
+import postcss from "postcss";
 import rule, { ruleName, messages } from "..";
+
+function logError(err) {
+  console.log(err.stack); // eslint-disable-line no-console
+}
 
 testRule(rule, {
   ruleName,
@@ -195,4 +200,20 @@ testRule(rule, {
       message: messages.rejected("@UNKNOWN")
     }
   ]
+});
+
+test("One warning for each unknown at rule", done => {
+  expect.assertions(3);
+
+  postcss([rule()])
+    .process("@foo { } @bar { }", { from: undefined })
+    .then(result => {
+      const warnings = result.warnings();
+
+      expect(warnings).toHaveLength(2);
+      expect(warnings[0].text).toBe(messages.rejected("@foo"));
+      expect(warnings[1].text).toBe(messages.rejected("@bar"));
+      done();
+    })
+    .catch(logError);
 });

--- a/src/rules/at-rule-no-unknown/index.js
+++ b/src/rules/at-rule-no-unknown/index.js
@@ -67,20 +67,18 @@ export default function(primaryOption, secondaryOptions) {
         root
       },
       warning => {
-        root.walkAtRules(atRule => {
-          const name = atRule.name;
+        const name = warning.node.name;
 
-          if (ignoreAtRules.indexOf(name) < 0) {
-            utils.report({
-              message: messages.rejected(`@${name}`),
-              ruleName,
-              result,
-              node: warning.node,
-              line: warning.line,
-              column: warning.column
-            });
-          }
-        });
+        if (ignoreAtRules.indexOf(name) < 0) {
+          utils.report({
+            message: messages.rejected(`@${name}`),
+            ruleName,
+            result,
+            node: warning.node,
+            line: warning.line,
+            column: warning.column
+          });
+        }
       }
     );
   };


### PR DESCRIPTION
This PR fixes a bug in `at-rule-no-unknown`. `utils.checkAgainstRule` and `root.walkAtRules` are both called, and both loop over rules. This leads to `n^2` warnings rather than `n`.

For example, linting the file with two unknowns:
```css
@foo { }
@bar { }
```
Leads to four warnings running:
```txt
1:1  Unexpected unknown at-rule "@foo" (at-rule-no-unknown)
1:1  Unexpected unknown at-rule "@foo" (at-rule-no-unknown)
2:1  Unexpected unknown at-rule "@bar" (at-rule-no-unknown)  
2:1  Unexpected unknown at-rule "@bar" (at-rule-no-unknown)
```

I wasn't sure how to add tests for this since it never failed any to begin with. If updated tests are required, I would appreciate any pointers!