### PR TITLE
Enforce LF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
@kristerkari I had to do this because on Windows with `autocrlf: true` which is the default, prettier changes the line endings to LF.

Since you are more familiar than I am with the codebase, let me know if there are any tests that expect CRLF in the test files.