### PR TITLE
sassValueParser/index.js: fix wrong regex

### DIFF
--- a/src/utils/sassValueParser/index.js
+++ b/src/utils/sassValueParser/index.js
@@ -914,7 +914,7 @@ function isFunctionAfter(after) {
   // `-fn()` is a valid function name, so if a - should be a sign/operator,
   // it must have a space after
   const matches = after.match(
-    /^\s*(-\s+|[+/*%]\s*)*[a-zA_Z_-][a-zA-Z_0-9-]*\(/
+    /^\s*(-\s+|[+/*%]\s*)*[a-zA-Z_-][a-zA-Z_0-9-]*\(/
   );
 
   if (matches) {


### PR DESCRIPTION
I assume this was meant to be `A-Z`. If not then `_` is duplicate and we should remove it.

Found with https://lgtm.com/projects/g/kristerkari/stylelint-scss/alerts?mode=list