### PR TITLE
sassValueParser/index.js: fix duplicate character in regex

### DIFF
--- a/src/utils/sassValueParser/index.js
+++ b/src/utils/sassValueParser/index.js
@@ -948,7 +948,7 @@ function isHexColorAfter(after) {
 
 function isHexColorBefore(before) {
   if (
-    before.search(/(?:[/(){},+/*%-\s]|^)#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/) !==
+    before.search(/(?:[/(){},+*%-\s]|^)#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/) !==
     -1
   ) {
     return true;


### PR DESCRIPTION
`/` is already present in the character list.

Found with https://lgtm.com/projects/g/kristerkari/stylelint-scss/alerts?mode=list