### PR TITLE
Allow keyword value in any conditions

### DIFF
--- a/src/rules/media-feature-value-dollar-variable/README.md
+++ b/src/rules/media-feature-value-dollar-variable/README.md
@@ -84,3 +84,21 @@ The following patterns are *not* considered warnings:
 ```scss
 @media screen and (min-width: funcName(10px)){ b { color: red; } }
 ```
+
+## Optional options
+
+### `ignore: ["keywords"]`
+
+#### `"keywords"`
+
+Ignore keyword values like `none`, `dark`, `fine`, `srgb`.
+
+For example, with `"always"`:
+
+The following patterns are *not* considered warnings:
+
+```scss
+@media screen and (max-width: $var) and (pointer: fine) {
+  a { display: none; }
+}
+```

--- a/src/rules/media-feature-value-dollar-variable/__tests__/index.js
+++ b/src/rules/media-feature-value-dollar-variable/__tests__/index.js
@@ -9,6 +9,14 @@ testRule(rule, {
   accept: [
     {
       code: `
+      @media print {
+        .navbar { display: none; }
+      }
+    `,
+      description: "Always. Example: no value."
+    },
+    {
+      code: `
       @media screen and (max-width: $val) {
         a { display: none; }
       }
@@ -204,6 +212,17 @@ testRule(rule, {
       column: 37,
       message: messages.expected,
       description: "Always. Example: function call as a value."
+    },
+    {
+      code: `
+      @media screen and (pointer: fine){
+        b { color: red; }
+      }
+    `,
+      line: 2,
+      column: 35,
+      message: messages.expected,
+      description: "Always. Example: keyword as a value."
     }
   ]
 });
@@ -215,6 +234,14 @@ testRule(rule, {
   syntax: "scss",
 
   accept: [
+    {
+      code: `
+      @media print {
+        .navbar { display: none; }
+      }
+    `,
+      description: "Never. Example: no value."
+    },
     {
       code: `
       @media screen and (min-width: 100px + 10px){
@@ -291,6 +318,58 @@ testRule(rule, {
       message: messages.rejected,
       description:
         "Never. Example: value is an interpolation of a math op on a var and a regular value."
+    }
+  ]
+});
+
+// Required ("always"), ignore keywords
+testRule(rule, {
+  ruleName,
+  config: ["always", { ignore: "keywords" }],
+  syntax: "scss",
+
+  accept: [
+    {
+      code: `
+      @media screen and (pointer: fine) {
+        a { display: none; }
+      }
+    `,
+      description: "Always. Example: value is a keyword."
+    },
+    {
+      code: `
+      @media screen and (max-width: $val) and (prefers-color-scheme: no-preference) {
+        a { display: none; }
+      }
+    `,
+      description: "Always. Example: values contain var and keyword with dash."
+    },
+    {
+      code: `
+      @media screen and (color-gamut: rec2020) {
+        a { display: none; }
+      }
+    `,
+      description: "Always. Example: value is a keyword with number."
+    }
+  ]
+});
+
+// Invalid option (false)
+testRule(rule, {
+  ruleName,
+  config: [false],
+  syntax: "scss",
+
+  accept: [
+    {
+      code: `
+      @media screen and (max-width: $val) and (min-width: 200px) {
+        a { display: none; }
+      }
+    `,
+      description: "Invalid option. Example: values are mixed."
     }
   ]
 });


### PR DESCRIPTION
Fix #438

CSS media features also have some keyword values, like `none`, `fine`, `srgb`. Usually you should not define a variable for them which is just overkill.

```scss
// valid
@media screen and (pointer: fine) and (min-width: $breakpoint) {}
```
In my project, I want all media feature use variables for sizes. But I don't want to define variables for standard keywords like `fine`, `dark`.