### PR TITLE
operator-no-unspaced: ignore operators inside @at-root

### DIFF
--- a/src/rules/operator-no-unspaced/__tests__/index.js
+++ b/src/rules/operator-no-unspaced/__tests__/index.js
@@ -1253,6 +1253,16 @@ testRule(rule, {
     {
       code: '@use "src/corners" as *;',
       description: "ignores @use"
+    },
+    {
+      code: `
+      .container {
+	      @at-root * {
+		      color: red;
+	      }
+      }
+      `,
+      description: "ignores @at-root"
     }
   ],
 

--- a/src/rules/operator-no-unspaced/index.js
+++ b/src/rules/operator-no-unspaced/index.js
@@ -178,8 +178,12 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
     }
 
     if (item.type === "atrule") {
-      // @forward and @use
-      if (item.name === "forward" || item.name === "use") {
+      // @forward, @use and @at-root
+      if (
+        item.name === "forward" ||
+        item.name === "use" ||
+        item.name === "at-root"
+      ) {
         return;
       }
 


### PR DESCRIPTION
Fixes #440