### PR TITLE
double-slash-comment-empty-line-before: add except:"inside-blocks", ignore:"inside-blocks"

### DIFF
--- a/src/rules/double-slash-comment-empty-line-before/README.md
+++ b/src/rules/double-slash-comment-empty-line-before/README.md
@@ -69,7 +69,9 @@ a {} // comment
 
 ## Optional options
 
-### `except: ["first-nested"]`
+### `except: ["first-nested", "inside-block"]`
+
+#### `"first-nested"`
 
 Reverse the primary option for `//`-comments that are nested and the first child of their parent node.
 
@@ -94,7 +96,34 @@ a {
 }
 ```
 
-### `ignore: ["between-comments", "stylelint-commands"]`
+#### `"inside-block"`
+
+Reverse the primary option for `//`-comments that are inside a block.
+
+For example, with `"always"`:
+
+The following patterns are considered warnings:
+
+```scss
+a {
+  background: pink;
+
+  // comment
+  color: pink;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+a {
+  background: pink;
+  // comment
+  color: pink;
+}
+```
+
+### `ignore: ["between-comments", "stylelint-commands", "inside-block"]`
 
 #### `"between-comments"`
 
@@ -146,6 +175,29 @@ The following patterns are *not* considered warnings:
 a {
   background: pink;
   // stylelint-disable color-no-hex
+  color: pink;
+}
+```
+
+#### `"inside-block"`
+
+Ignore `//`-comments that are inside a block.
+
+For example, the following patterns are *not* considered warnings:
+
+```scss
+a {
+  background: pink;
+  // comment
+  color: pink;
+}
+```
+
+```scss
+a {
+  background: pink;
+
+  // comment
   color: pink;
 }
 ```

--- a/src/rules/double-slash-comment-empty-line-before/__tests__/index.js
+++ b/src/rules/double-slash-comment-empty-line-before/__tests__/index.js
@@ -176,6 +176,67 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: ["always", { except: ["inside-block"] }],
+  syntax: "scss",
+  skipBasicChecks: true,
+  fix: true,
+
+  accept: [
+    {
+      code: `
+      a {
+        // Inside block, no empty line.
+        color: pink;
+      }
+    `,
+      description: "Inside block, no empty line."
+    }
+  ],
+
+  reject: [
+    {
+      code: `
+      a {
+
+        // Inside rule block, with empty line (rejected).
+        color: pink;
+      }
+    `,
+      fixed: `
+      a {
+        // Inside rule block, with empty line (rejected).
+        color: pink;
+      }
+    `,
+      description: "Inside rule block, with empty line (rejected).",
+      message: messages.rejected,
+      line: 4,
+      column: 9
+    },
+    {
+      code: `
+      @if 1 == 2 {
+
+        // Inside at-rule block, with empty line (rejected).
+        p { color: pink; }
+      }
+    `,
+      fixed: `
+      @if 1 == 2 {
+        // Inside at-rule block, with empty line (rejected).
+        p { color: pink; }
+      }
+    `,
+      description: "Inside at-rule block, with empty line (rejected).",
+      message: messages.rejected,
+      line: 4,
+      column: 9
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   config: ["always", { ignore: ["stylelint-commands"] }],
   syntax: "scss",
   skipBasicChecks: true,
@@ -267,6 +328,59 @@ testRule(rule, {
       }
     `,
       description: "Multiple comments, inside ruleset, no empty lines.",
+      message: messages.expected
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: ["always", { ignore: ["inside-block"] }],
+  syntax: "scss",
+  skipBasicChecks: true,
+  fix: true,
+
+  accept: [
+    {
+      code: `
+      body { color: blue; }
+
+      // comment 1
+    `,
+      description: "Empty line before root level comment"
+    },
+    {
+      code: `
+      p {
+        // comment 1
+        color: red;
+      }
+    `,
+      description: "Non-empty line before comment inside a rule block"
+    },
+    {
+      code: `
+      @if 1 == 2 {
+        // comment 1
+        p { color: red; }
+      }
+    `,
+      description: "Non-empty line before comment inside an at-rule block"
+    }
+  ],
+
+  reject: [
+    {
+      code: `
+      body { color: blue; }
+      // comment 1
+    `,
+      fixed: `
+      body { color: blue; }
+
+      // comment 1
+    `,
+      description: "Non-empty line before root level comment",
       message: messages.expected
     }
   ]
@@ -426,6 +540,68 @@ testRule(rule, {
     `,
       description: "issue #321",
       message: messages.rejected
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: ["never", { except: ["inside-block"] }],
+  syntax: "scss",
+  skipBasicChecks: true,
+  fix: true,
+
+  accept: [
+    {
+      code: `
+      a {
+
+        // Inside block, with empty line.
+        color: pink;
+      }
+    `,
+      description: "Inside block, with empty line."
+    }
+  ],
+
+  reject: [
+    {
+      code: `
+      a {
+        // Inside rule block, no empty line (rejected).
+        color: pink;
+      }
+    `,
+      fixed: `
+      a {
+
+        // Inside rule block, no empty line (rejected).
+        color: pink;
+      }
+    `,
+      description: "Inside rule block, no empty line (rejected).",
+      message: messages.expected,
+      line: 3,
+      column: 9
+    },
+    {
+      code: `
+      @if 1 == 2 {
+        // Inside at-rule block, no empty line (rejected).
+        p { color: pink; }
+      }
+    `,
+      fixed: `
+      @if 1 == 2 {
+
+        // Inside at-rule block, no empty line (rejected).
+        p { color: pink; }
+      }
+    `,
+      description: "Inside at-rule block, no empty line (rejected).",
+      message: messages.expected,
+      line: 3,
+      column: 9
     }
   ]
 });

--- a/src/rules/double-slash-comment-empty-line-before/index.js
+++ b/src/rules/double-slash-comment-empty-line-before/index.js
@@ -29,8 +29,8 @@ export default function(expectation, options, context) {
       {
         actual: options,
         possible: {
-          except: ["first-nested"],
-          ignore: ["stylelint-commands", "between-comments"]
+          except: ["first-nested", "inside-block"],
+          ignore: ["stylelint-commands", "between-comments", "inside-block"]
         },
         optional: true
       }
@@ -63,6 +63,14 @@ export default function(expectation, options, context) {
         return;
       }
 
+      // Optionally ignore comments inside blocks
+      if (
+        comment.parent !== root &&
+        optionsHaveIgnored(options, "inside-block")
+      ) {
+        return;
+      }
+
       // Optionally ignore newlines between comments
       const prev = comment.prev();
 
@@ -83,6 +91,14 @@ export default function(expectation, options, context) {
           comment === comment.parent.first
         ) {
           return false;
+        }
+
+        // Reverse expectation for comments inside blocks
+        if (
+          comment.parent !== root &&
+          optionsHaveException(options, "inside-block")
+        ) {
+          return expectation === "never";
         }
 
         return expectation === "always";


### PR DESCRIPTION
Fixes #343 