### PR TITLE
Fix index for function-* rules

### DIFF
--- a/src/rules/function-color-relative/__tests__/index.js
+++ b/src/rules/function-color-relative/__tests__/index.js
@@ -1,4 +1,4 @@
-import rule, { ruleName, messages } from "..";
+import rule, { messages, ruleName } from "..";
 
 testRule(rule, {
   ruleName,
@@ -24,7 +24,9 @@ testRule(rule, {
         }
       `,
       description: "does not accept the saturate function",
-      message: messages.rejected
+      message: messages.rejected,
+      line: 3,
+      column: 18
     },
     {
       code: `
@@ -33,7 +35,9 @@ testRule(rule, {
         }
       `,
       description: "does not accept the desaturate function",
-      message: messages.rejected
+      message: messages.rejected,
+      line: 3,
+      column: 18
     },
     {
       code: `
@@ -42,7 +46,9 @@ testRule(rule, {
         }
       `,
       description: "does not accept the darken function",
-      message: messages.rejected
+      message: messages.rejected,
+      line: 3,
+      column: 18
     },
     {
       code: `
@@ -51,7 +57,9 @@ testRule(rule, {
         }
       `,
       description: "does not accept the lighten function",
-      message: messages.rejected
+      message: messages.rejected,
+      line: 3,
+      column: 18
     },
     {
       code: `
@@ -60,7 +68,9 @@ testRule(rule, {
         }
       `,
       description: "does not accept the opacify function",
-      message: messages.rejected
+      message: messages.rejected,
+      line: 3,
+      column: 18
     },
     {
       code: `
@@ -69,7 +79,9 @@ testRule(rule, {
         }
       `,
       description: "does not accept the fade-in function",
-      message: messages.rejected
+      message: messages.rejected,
+      line: 3,
+      column: 18
     },
     {
       code: `
@@ -78,7 +90,9 @@ testRule(rule, {
         }
       `,
       description: "does not accept the transparentize function",
-      message: messages.rejected
+      message: messages.rejected,
+      line: 3,
+      column: 18
     },
     {
       code: `
@@ -87,7 +101,9 @@ testRule(rule, {
         }
       `,
       description: "does not accept the fade-out function",
-      message: messages.rejected
+      message: messages.rejected,
+      line: 3,
+      column: 18
     }
   ]
 });

--- a/src/rules/function-color-relative/index.js
+++ b/src/rules/function-color-relative/index.js
@@ -1,6 +1,6 @@
-import { utils } from "stylelint";
-import { namespace } from "../../utils";
 import valueParser from "postcss-value-parser";
+import { utils } from "stylelint";
+import { declarationValueIndex, namespace } from "../../utils";
 
 export const ruleName = namespace("function-color-relative");
 
@@ -40,6 +40,7 @@ function rule(primary) {
           utils.report({
             message: messages.rejected,
             node: decl,
+            index: declarationValueIndex(decl) + node.sourceIndex,
             result,
             ruleName
           });

--- a/src/rules/function-quote-no-quoted-strings-inside/__tests__/index.js
+++ b/src/rules/function-quote-no-quoted-strings-inside/__tests__/index.js
@@ -1,4 +1,4 @@
-import rule, { ruleName, messages } from "..";
+import rule, { messages, ruleName } from "..";
 
 // always-intermediate
 testRule(rule, {
@@ -37,6 +37,7 @@ testRule(rule, {
       description: "does not accept strings with quotes",
       message: messages.rejected,
       line: 3,
+      column: 24,
       fixed: `
         p {
           font-family: "Helvetica";
@@ -53,6 +54,7 @@ testRule(rule, {
       description:
         "does not accept variables representing strings that are quoted.",
       line: 4,
+      column: 24,
       fixed: `
         $font: "Helvetica";
         p {

--- a/src/rules/function-quote-no-quoted-strings-inside/index.js
+++ b/src/rules/function-quote-no-quoted-strings-inside/index.js
@@ -1,6 +1,10 @@
-import { utils } from "stylelint";
-import { namespace, isNativeCssFunction } from "../../utils";
 import valueParser from "postcss-value-parser";
+import { utils } from "stylelint";
+import {
+  declarationValueIndex,
+  isNativeCssFunction,
+  namespace
+} from "../../utils";
 
 export const ruleName = namespace("function-quote-no-quoted-strings-inside");
 
@@ -58,6 +62,7 @@ function rule(primary, _, context) {
             utils.report({
               message: messages.rejected,
               node: decl,
+              index: declarationValueIndex(decl) + node.sourceIndex,
               result,
               ruleName
             });

--- a/src/rules/function-unquote-no-unquoted-strings-inside/__tests__/index.js
+++ b/src/rules/function-unquote-no-unquoted-strings-inside/__tests__/index.js
@@ -1,4 +1,4 @@
-import rule, { ruleName, messages } from "..";
+import rule, { messages, ruleName } from "..";
 
 // always-intermediate
 testRule(rule, {
@@ -37,6 +37,7 @@ testRule(rule, {
       description: "does not accept strings without quotes",
       message: messages.rejected,
       line: 3,
+      column: 24,
       fixed: `
         p {
           font-family: Helvetica;
@@ -53,6 +54,7 @@ testRule(rule, {
       description:
         "does not accept variables representing strings that are quoted.",
       line: 4,
+      column: 24,
       fixed: `
         $font: Helvetica;
         p {

--- a/src/rules/function-unquote-no-unquoted-strings-inside/index.js
+++ b/src/rules/function-unquote-no-unquoted-strings-inside/index.js
@@ -1,6 +1,10 @@
-import { utils } from "stylelint";
-import { namespace, isNativeCssFunction } from "../../utils";
 import valueParser from "postcss-value-parser";
+import { utils } from "stylelint";
+import {
+  declarationValueIndex,
+  isNativeCssFunction,
+  namespace
+} from "../../utils";
 
 export const ruleName = namespace(
   "function-unquote-no-unquoted-strings-inside"
@@ -63,6 +67,7 @@ function rule(primary, _, context) {
             utils.report({
               message: messages.rejected,
               node: decl,
+              index: declarationValueIndex(decl) + node.sourceIndex,
               result,
               ruleName
             });

--- a/src/rules/no-global-function-names/__tests__/index.js
+++ b/src/rules/no-global-function-names/__tests__/index.js
@@ -1,4 +1,4 @@
-import rule, { ruleName, messages } from "..";
+import rule, { messages, ruleName } from "..";
 
 testRule(rule, {
   ruleName,
@@ -259,6 +259,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("red"),
       description: "red"
     },
@@ -269,6 +270,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("blue"),
       description: "blue"
     },
@@ -279,6 +281,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("green"),
       description: "green"
     },
@@ -289,6 +292,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("mix"),
       description: "mix"
     },
@@ -299,6 +303,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("hue"),
       description: "hue"
     },
@@ -309,6 +314,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("saturation"),
       description: "saturation"
     },
@@ -319,6 +325,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("lightness"),
       description: "lightness"
     },
@@ -329,6 +336,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("alpha"),
       description: "alpha"
     },
@@ -339,6 +347,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("adjust-color"),
       description: "adjust-color"
     },
@@ -349,6 +358,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("scale-color"),
       description: "scale-color"
     },
@@ -359,6 +369,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("change-color"),
       description: "change-color"
     },
@@ -369,6 +380,7 @@ testRule(rule, {
       }
     `,
       line: 3,
+      column: 21,
       message: messages.rejected("ie-hex-str"),
       description: "ie-hex-str"
     },
@@ -377,6 +389,7 @@ testRule(rule, {
       a {b: map-get((), 1)}
     `,
       line: 2,
+      column: 13,
       message: messages.rejected("map-get"),
       description: "map-get"
     },
@@ -385,7 +398,8 @@ testRule(rule, {
       $font-weights: ("regular": 400, "medium": 500, "bold": 700)
       @debug map-has-key($font-weights, "regular")
     `,
-      line: 2,
+      line: 3,
+      column: 14,
       message: messages.rejected("map-has-key"),
       description: "map-has-key"
     },
@@ -394,7 +408,8 @@ testRule(rule, {
       $font-weights: ("regular": 400, "medium": 500, "bold": 700)
       @debug map-remove($font-weights, "regular")
     `,
-      line: 2,
+      line: 3,
+      column: 14,
       message: messages.rejected("map-remove"),
       description: "map-remove"
     },
@@ -403,7 +418,8 @@ testRule(rule, {
       $font-weights: ("regular": 400, "medium": 500, "bold": 700)
       @debug map-keys($font-weights)
     `,
-      line: 2,
+      line: 3,
+      column: 14,
       message: messages.rejected("map-keys"),
       description: "map-keys"
     },
@@ -412,7 +428,8 @@ testRule(rule, {
       $font-weights: ("regular": 400, "medium": 500, "bold": 700)
       @debug map-values($font-weights)
     `,
-      line: 2,
+      line: 3,
+      column: 14,
       message: messages.rejected("map-values"),
       description: "map-values"
     }

--- a/src/rules/no-global-function-names/index.js
+++ b/src/rules/no-global-function-names/index.js
@@ -1,6 +1,6 @@
-import { utils } from "stylelint";
-import { namespace } from "../../utils";
 import valueParser from "postcss-value-parser";
+import { utils } from "stylelint";
+import { declarationValueIndex, namespace } from "../../utils";
 
 const rules = {
   red: "color",
@@ -135,6 +135,7 @@ export default function(value) {
           utils.report({
             message: messages.rejected(node.value),
             node: decl,
+            index: declarationValueIndex(decl) + node.sourceIndex,
             result,
             ruleName
           });


### PR DESCRIPTION
The rules belonging to the group `function` were missing the index setting, which caused the warning to highlight the CSS property instead of the function name.