### PR TITLE
Fix comment-no-load only covering first line

### DIFF
--- a/src/rules/comment-no-loud/__tests__/index.js
+++ b/src/rules/comment-no-loud/__tests__/index.js
@@ -35,6 +35,23 @@ testRule(rule, {
       line: 2,
       column: 9,
       message: messages.expected
+    },
+    {
+      code: `
+      i {
+        font-style: italic;
+      }
+
+      /* comment line */
+
+      b {
+        font-weight: bold;
+      }
+    `,
+      description: "Comment sandwiched between rules",
+      line: 6,
+      column: 7,
+      message: messages.expected
     }
   ]
 });

--- a/src/rules/comment-no-loud/__tests__/index.js
+++ b/src/rules/comment-no-loud/__tests__/index.js
@@ -21,6 +21,8 @@ testRule(rule, {
       /* comment */
     `,
       description: "One line with optional ending",
+      line: 2,
+      column: 7,
       message: messages.expected
     },
     {
@@ -30,6 +32,8 @@ testRule(rule, {
         */
     `,
       description: "Multline comment with optional ending on next line",
+      line: 2,
+      column: 9,
       message: messages.expected
     }
   ]

--- a/src/rules/comment-no-loud/index.js
+++ b/src/rules/comment-no-loud/index.js
@@ -33,7 +33,10 @@ function rule(primary) {
 function isLoudComment(comment) {
   const regex = new RegExp(/^[ \t\n]*\/\*/);
 
-  return regex.test(comment.source.input.css);
+  const splitComment = comment.source.input.css.split("\n");
+  const commentFirstLine = splitComment[comment.source.start.line - 1];
+
+  return regex.test(commentFirstLine);
 }
 
 export default rule;


### PR DESCRIPTION
Addresses https://github.com/kristerkari/stylelint-scss/issues/439

This changes the approach to looking up comments for the comment-no-loud
rule. This rule had an issue where it would only identify comments if
they were the first node within an SCSS file.

Previously this check matched a regex against `source.input.css` of the
comment node. `source.input.css` is actually the full input of the
source file and not the input of the node (as I imagine was expected
when this was initially authored). This meant that only comments that
were not preceded by any other nodes matched the rule. The tests all
succeeded for this as they all checked against the first node.

This new approach instead takes the source input and splits into an array
based on a `\n` separator. It then looks up the first line of the
comment with `source.start.line` variable. This provides the first
line of the comment input as was given in the source file.

I did also try using `comment.toString()` as a simpler means to get the
original source value, however this approach didn't provide an exact
copy of the original input and instead converted SCSS comments (`//`)
into CSS ones (`/*`) meaning that all SCSS comments were identified as
loud.