### PR TITLE
Fix duplicate rule names in `at-rule-no-unknown` message

### DIFF
--- a/src/rules/at-rule-no-unknown/__tests__/index.js
+++ b/src/rules/at-rule-no-unknown/__tests__/index.js
@@ -217,3 +217,9 @@ test("One warning for each unknown at rule", done => {
     })
     .catch(logError);
 });
+
+test("messages", () => {
+  expect(messages.rejected("@foo")).toBe(
+    'Unexpected unknown at-rule "@foo" (scss/at-rule-no-unknown)'
+  );
+});

--- a/src/rules/at-rule-no-unknown/index.js
+++ b/src/rules/at-rule-no-unknown/index.js
@@ -30,7 +30,11 @@ const ruleToCheckAgainst = "at-rule-no-unknown";
 export const ruleName = namespace(ruleToCheckAgainst);
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: rules[ruleToCheckAgainst].messages.rejected
+  rejected: (...args) => {
+    return rules[ruleToCheckAgainst].messages
+      .rejected(...args)
+      .replace(` (${ruleToCheckAgainst})`, "");
+  }
 });
 
 export default function(primaryOption, secondaryOptions) {


### PR DESCRIPTION
Fix #480