### PR TITLE
Unify messages for `comment-no-empty` and `scss/comment-no-empty`

### DIFF
--- a/src/rules/comment-no-empty/__tests__/index.js
+++ b/src/rules/comment-no-empty/__tests__/index.js
@@ -31,7 +31,7 @@ testRule(rule, {
     },
     {
       code: `
-        /* 
+        /*
         */
     `,
       description: "Empty multline block comment",
@@ -41,7 +41,7 @@ testRule(rule, {
     },
     {
       code: `
-        /* 
+        /*
 
         */
       `,
@@ -60,7 +60,7 @@ testRule(rule, {
     },
     {
       code: `
-        //     
+        //
       `,
       description: "Empty double slash comment with spaces",
       message: messages.rejected,
@@ -78,7 +78,7 @@ testRule(rule, {
     },
     {
       code: `
-        width: 100px; // 
+        width: 100px; //
       `,
       description: "Empty inline comment",
       message: messages.rejected,
@@ -96,12 +96,18 @@ testRule(rule, {
     },
     {
       code: `
-      /* */width: 100px; 
+      /* */width: 100px;
       `,
       description: "Empty inline block comment prepends code",
       message: messages.rejected,
       line: 2,
       column: 7
-    }   
+    }
   ]
+});
+
+test("messages", () => {
+  expect(messages.rejected).toBe(
+    "Unexpected empty comment (scss/comment-no-empty)"
+  );
 });

--- a/src/rules/comment-no-empty/index.js
+++ b/src/rules/comment-no-empty/index.js
@@ -6,11 +6,10 @@ const coreRuleName = "comment-no-empty";
 export const ruleName = namespace(coreRuleName);
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: (...args) => {
-    return rules[coreRuleName].messages
-      .rejected(...args)
-      .replace(` (${coreRuleName})`, "");
-  }
+  rejected: rules[coreRuleName].messages.rejected.replace(
+    ` (${coreRuleName})`,
+    ""
+  )
 });
 
 function rule(primary) {

--- a/src/rules/comment-no-empty/index.js
+++ b/src/rules/comment-no-empty/index.js
@@ -1,10 +1,16 @@
-import { utils } from "stylelint";
+import { rules, utils } from "stylelint";
 import { namespace } from "../../utils";
 
-export const ruleName = namespace("comment-no-empty");
+const coreRuleName = "comment-no-empty";
+
+export const ruleName = namespace(coreRuleName);
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Unexpected empty comment"
+  rejected: (...args) => {
+    return rules[coreRuleName].messages
+      .rejected(...args)
+      .replace(` (${coreRuleName})`, "");
+  }
 });
 
 function rule(primary) {


### PR DESCRIPTION
This change aims to respect the message of the stylelint's core rule [`comment-no-empty`](https://github.com/stylelint/stylelint/blob/a8042e7192cad993081cf982901948dbd5004048/lib/rules/comment-no-empty/index.js#L12).
Because the `scss/comment-no-empty` is essentially an extension of the core rule.

Related to #481 and #483