### PR TITLE
Add recommended rules to installation part of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,20 @@ npm install stylelint stylelint-scss
 
 Create the `.stylelintrc.json` config file (or open the existing one), add `stylelint-scss` to the plugins array and the rules you need to the rules list. All rules from stylelint-scss need to be namespaced with `scss`.
 
-```json
+```js
 {
   "plugins": [
     "stylelint-scss"
   ],
   "rules": {
+    // recommended rules
+    "at-rule-no-unknown": null,
+    "scss/at-rule-no-unknown": true,
+    ...
+    ...
+    // any other rules you'd want to change e.g.
     "scss/dollar-variable-pattern": "^foo",
     "scss/selector-no-redundant-nesting-selector": true,
-    ...
   }
 }
 ```


### PR DESCRIPTION
These rules will help users getting rid of style-lint warnings for SCSS scripts.

We can assume that plugin users will use SCSS therefore it might make sense to have these rules as part of the installation process.