### PR TITLE
Fix lack of note about autofix for at-rule-conditional-no-parentheses rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Please also see the [example configs](./docs/examples/) for special cases.
 
 ### `@`-rule
 
-- [`at-rule-conditional-no-parentheses`](./src/rules/at-rule-conditional-no-parentheses/README.md): Disallow parentheses in conditional @ rules (if, elsif, while).
+- [`at-rule-conditional-no-parentheses`](./src/rules/at-rule-conditional-no-parentheses/README.md): Disallow parentheses in conditional @ rules (if, elsif, while) (Autofixable).
 - [`at-rule-no-unknown`](./src/rules/at-rule-no-unknown/README.md): Disallow unknown at-rules. Should be used **instead of** stylelint's [at-rule-no-unknown](https://stylelint.io/user-guide/rules/at-rule-no-unknown).
 
 ### `$`-variable

--- a/src/rules/at-rule-conditional-no-parentheses/README.md
+++ b/src/rules/at-rule-conditional-no-parentheses/README.md
@@ -8,7 +8,7 @@ Disallow parentheses in conditional @ rules (if, elsif, while)
  * Get rid of parentheses like this. */
 ```
 
-
+The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
 
 ## Options
 


### PR DESCRIPTION
It's not documented, but the rule seems to have the ability of autofix.