### PR TITLE
selector-nest-combinators: fix error being thrown with nested combinators

### DIFF
--- a/src/rules/selector-nest-combinators/__tests__/index.js
+++ b/src/rules/selector-nest-combinators/__tests__/index.js
@@ -32,6 +32,17 @@ testRule(rule, {
     },
     {
       code: `
+      .foo {
+        & > {
+          .bar {}
+        }
+      }
+      `,
+      description:
+        "when direct descendant combinators are nested + a nested class"
+    },
+    {
+      code: `
       .baz {
         .foo.bar & {}
       }

--- a/src/rules/selector-nest-combinators/index.js
+++ b/src/rules/selector-nest-combinators/index.js
@@ -93,7 +93,7 @@ export default function(expectation) {
             }
 
             if (node.type === "combinator") {
-              if (!chainingTypes.includes(node.next().type)) {
+              if (node.next() && !chainingTypes.includes(node.next().type)) {
                 return;
               }
 


### PR DESCRIPTION
Fixes #497